### PR TITLE
Add a board file for Gnarly Grey's iCE40UP5K 'Upduino' board

### DIFF
--- a/nmigen_boards/upduino.py
+++ b/nmigen_boards/upduino.py
@@ -1,0 +1,47 @@
+import os
+import subprocess
+
+from nmigen.build import *
+from nmigen.vendor.lattice_ice40 import *
+from nmigen_boards.resources import *
+
+######################################################
+# Board definition file for Gnarly Grey"s "Upduino". #
+######################################################
+
+__all__ = ["UpduinoPlatform"]
+
+class UpduinoPlatform(LatticeICE40Platform):
+    device      = "iCE40UP5K"
+    package     = "SG48"
+    default_clk = "SB_HFOSC"
+    # This division setting selects the internal oscillator speed:
+    # 0: 48MHz, 1: 24MHz, 2: 12MHz, 3: 6MHz.
+    hfosc_div   = 0
+    resources   = [
+        # The board has one RGB LED connected to the PWM pins.
+        *LEDResources(pins = "39 40 41", invert = True,
+                      attrs = Attrs(IO_STANDARD = "SB_LVCMOS")),
+        Resource("led_b", 0, PinsN("39", dir = "o"),
+                 Attrs(IO_STANDARD = "SB_LVCMOS")),
+        Resource("led_g", 0, PinsN("40", dir = "o"),
+                 Attrs(IO_STANDARD = "SB_LVCMOS")),
+        Resource("led_r", 0, PinsN("41", dir = "o"),
+                 Attrs(IO_STANDARD = "SB_LVCMOS")),
+
+        # SPI Flash connection.
+        *SPIFlashResources(0, cs = "16", clk = "15",
+                           miso = "17", mosi = "14",
+                           attrs = Attrs( IO_STANDARD = "SB_LVCMOS"))
+    ]
+    connectors  = [
+        # "Left" row of header pins (JP5 on the schematic)
+        Connector("j", 0, "- - 23 25 26 27 32 35 31 37 34 43 36 42 38 28"),
+        # "Right" row of header pins (JP6 on the schematic)
+        Connector("j", 1, "12 21 13 19 18 11 9 6 44 4 3 48 45 47 46 2")
+    ]
+
+    def toolchain_program(self, products, name):
+        iceprog = os.environ.get("ICEPROG", "iceprog")
+        with products.extract("{}.bin".format(name)) as bitstream_fn:
+            subprocess.check_call([iceprog, bitstream_fn])

--- a/nmigen_boards/upduino.py
+++ b/nmigen_boards/upduino.py
@@ -22,9 +22,9 @@ class UpduinoPlatform(LatticeICE40Platform):
         # The board has one RGB LED connected to the PWM pins.
         *LEDResources(pins = "39 40 41", invert = True,
                       attrs = Attrs(IO_STANDARD = "SB_LVCMOS")),
-        Resource("led_b", 0, PinsN("39", dir = "o"),
+        Resource("led_g", 0, PinsN("39", dir = "o"),
                  Attrs(IO_STANDARD = "SB_LVCMOS")),
-        Resource("led_g", 0, PinsN("40", dir = "o"),
+        Resource("led_b", 0, PinsN("40", dir = "o"),
                  Attrs(IO_STANDARD = "SB_LVCMOS")),
         Resource("led_r", 0, PinsN("41", dir = "o"),
                  Attrs(IO_STANDARD = "SB_LVCMOS")),

--- a/nmigen_boards/upduino.py
+++ b/nmigen_boards/upduino.py
@@ -3,7 +3,7 @@ import subprocess
 
 from nmigen.build import *
 from nmigen.vendor.lattice_ice40 import *
-from nmigen_boards.resources import *
+from .resources import *
 
 ######################################################
 # Board definition file for Gnarly Grey"s "Upduino". #
@@ -45,3 +45,7 @@ class UpduinoPlatform(LatticeICE40Platform):
         iceprog = os.environ.get("ICEPROG", "iceprog")
         with products.extract("{}.bin".format(name)) as bitstream_fn:
             subprocess.check_call([iceprog, bitstream_fn])
+
+if __name__ == "__main__":
+    from .test.blinky import *
+    ICEStickPlatform().build(Blinky(), do_program=True)

--- a/nmigen_boards/upduino.py
+++ b/nmigen_boards/upduino.py
@@ -48,4 +48,4 @@ class UpduinoPlatform(LatticeICE40Platform):
 
 if __name__ == "__main__":
     from .test.blinky import *
-    ICEStickPlatform().build(Blinky(), do_program=True)
+    UpduinoPlatform().build(Blinky(), do_program=True)

--- a/nmigen_boards/upduino.py
+++ b/nmigen_boards/upduino.py
@@ -5,34 +5,29 @@ from nmigen.build import *
 from nmigen.vendor.lattice_ice40 import *
 from .resources import *
 
-######################################################
-# Board definition file for Gnarly Grey"s "Upduino". #
-######################################################
 
 __all__ = ["UpduinoPlatform"]
+
 
 class UpduinoPlatform(LatticeICE40Platform):
     device      = "iCE40UP5K"
     package     = "SG48"
     default_clk = "SB_HFOSC"
-    # This division setting selects the internal oscillator speed:
-    # 0: 48MHz, 1: 24MHz, 2: 12MHz, 3: 6MHz.
     hfosc_div   = 0
     resources   = [
-        # The board has one RGB LED connected to the PWM pins.
-        *LEDResources(pins = "39 40 41", invert = True,
-                      attrs = Attrs(IO_STANDARD = "SB_LVCMOS")),
-        Resource("led_g", 0, PinsN("39", dir = "o"),
-                 Attrs(IO_STANDARD = "SB_LVCMOS")),
-        Resource("led_b", 0, PinsN("40", dir = "o"),
-                 Attrs(IO_STANDARD = "SB_LVCMOS")),
-        Resource("led_r", 0, PinsN("41", dir = "o"),
-                 Attrs(IO_STANDARD = "SB_LVCMOS")),
+        *LEDResources(pins="39 40 41", invert=True,
+                      attrs=Attrs(IO_STANDARD="SB_LVCMOS")),
+        Resource("led_g", 0, PinsN("39", dir="o"),
+                 Attrs(IO_STANDARD="SB_LVCMOS")),
+        Resource("led_b", 0, PinsN("40", dir="o"),
+                 Attrs(IO_STANDARD="SB_LVCMOS")),
+        Resource("led_r", 0, PinsN("41", dir="o"),
+                 Attrs(IO_STANDARD="SB_LVCMOS")),
 
-        # SPI Flash connection.
-        *SPIFlashResources(0, cs = "16", clk = "15",
-                           miso = "17", mosi = "14",
-                           attrs = Attrs( IO_STANDARD = "SB_LVCMOS"))
+        *SPIFlashResources(0,
+            cs="16", clk="15", miso="17", mosi="14",
+            attrs=Attrs(IO_STANDARD="SB_LVCMOS")
+        ),
     ]
     connectors  = [
         # "Left" row of header pins (JP5 on the schematic)
@@ -45,6 +40,7 @@ class UpduinoPlatform(LatticeICE40Platform):
         iceprog = os.environ.get("ICEPROG", "iceprog")
         with products.extract("{}.bin".format(name)) as bitstream_fn:
             subprocess.check_call([iceprog, bitstream_fn])
+
 
 if __name__ == "__main__":
     from .test.blinky import *

--- a/nmigen_boards/upduino_v1.py
+++ b/nmigen_boards/upduino_v1.py
@@ -1,15 +1,12 @@
-import os
-import subprocess
-
 from nmigen.build import *
 from nmigen.vendor.lattice_ice40 import *
 from .resources import *
 
 
-__all__ = ["UpduinoPlatform"]
+__all__ = ["UpduinoV1Platform"]
 
 
-class UpduinoPlatform(LatticeICE40Platform):
+class UpduinoV1Platform(LatticeICE40Platform):
     device      = "iCE40UP5K"
     package     = "SG48"
     default_clk = "SB_HFOSC"
@@ -36,12 +33,4 @@ class UpduinoPlatform(LatticeICE40Platform):
         Connector("j", 1, "12 21 13 19 18 11 9 6 44 4 3 48 45 47 46 2")
     ]
 
-    def toolchain_program(self, products, name):
-        iceprog = os.environ.get("ICEPROG", "iceprog")
-        with products.extract("{}.bin".format(name)) as bitstream_fn:
-            subprocess.check_call([iceprog, bitstream_fn])
-
-
-if __name__ == "__main__":
-    from .test.blinky import *
-    UpduinoPlatform().build(Blinky(), do_program=True)
+    # This board doesn't have an integrated programmer.

--- a/nmigen_boards/upduino_v2.py
+++ b/nmigen_boards/upduino_v2.py
@@ -1,0 +1,30 @@
+import os
+import subprocess
+
+from nmigen.build import *
+from nmigen.vendor.lattice_ice40 import *
+from .resources import *
+from .upduino_v1 import UpduinoV1Platform
+
+
+__all__ = ["UpduinoV2Platform"]
+
+
+class UpduinoV2Platform(UpduinoV1Platform):
+    # Mostly identical to the V1 board, but it has an integrated
+    # programmer and a 12MHz oscillator which is NC by default.
+    resources = UpduinoV1Platform.resources + [
+        # Solder pin 12 to the adjacent 'J8' osc_out pin to enable.
+        Resource("clk12", 0, Pins("12", dir="i"),
+                 Clock(12e6), Attrs(IO_STANDARD="SB_LVCMOS")),
+    ]
+
+    def toolchain_program(self, products, name):
+        iceprog = os.environ.get("ICEPROG", "iceprog")
+        with products.extract("{}.bin".format(name)) as bitstream_filename:
+            subprocess.check_call([iceprog, bitstream_filename])
+
+
+if __name__ == "__main__":
+    from .test.blinky import *
+    UpduinoV2Platform().build(Blinky(), do_program=True)


### PR DESCRIPTION
It's an open-source board which Lattice also sells bundled with a camera module. Design files: https://github.com/gtjennings1/UPDuino_v2_0

The board's oscillator is not connected to the FPGA by default, so this board file relies on support for iCE40 internal oscillators:

https://github.com/nmigen/nmigen/pull/338