### PR TITLE
Add role to UARTResouce and fix UART flow control pin inconsistencies

### DIFF
--- a/nmigen_boards/blackice.py
+++ b/nmigen_boards/blackice.py
@@ -28,8 +28,9 @@ class BlackIcePlatform(LatticeICE40Platform):
         *SwitchResources(pins="37 38 39 41", invert=True, attrs=Attrs(IO_STANDARD="SB_LVCMOS")),
 
         UARTResource(0,
-            rx="88", tx="85", rts="91", cts="94",
-            attrs=Attrs(IO_STANDARD="SB_LVCMOS", PULLUP=1)
+            rx="88", tx="85",
+            attrs=Attrs(IO_STANDARD="SB_LVCMOS", PULLUP=1),
+            role="dce"
         ),
 
         SRAMResource(0,

--- a/nmigen_boards/blackice_ii.py
+++ b/nmigen_boards/blackice_ii.py
@@ -30,7 +30,8 @@ class BlackIceIIPlatform(LatticeICE40Platform):
 
         UARTResource(0,
             rx="88", tx="85", rts="91", cts="94",
-            attrs=Attrs(IO_STANDARD="SB_LVCMOS", PULLUP=1)
+            attrs=Attrs(IO_STANDARD="SB_LVCMOS", PULLUP=1),
+            role="dce"
         ),
 
         SRAMResource(0,

--- a/nmigen_boards/de0.py
+++ b/nmigen_boards/de0.py
@@ -44,7 +44,8 @@ class DE0Platform(IntelPlatform):
 
         UARTResource(0,
             rx="U22", tx="U21", rts="V22", cts="V21",
-            attrs=Attrs(io_standard="3.3-V LVTTL")),
+            attrs=Attrs(io_standard="3.3-V LVTTL"),
+            role="dce"),
 
         Resource("display_hd44780", 0,
             Subsignal("e", Pins("E21", dir="o")),

--- a/nmigen_boards/ice40_hx8k_b_evn.py
+++ b/nmigen_boards/ice40_hx8k_b_evn.py
@@ -23,8 +23,9 @@ class ICE40HX8KBEVNPlatform(LatticeICE40Platform):
         ), # D2..D9
 
         UARTResource(0,
-            rx="B10", tx="B12", rts="A15", cts="B13", dtr="B14", dsr="A16", dcd="B15",
-            attrs=Attrs(IO_STANDARD="SB_LVCMOS", PULLUP=1)
+            rx="B10", tx="B12", rts="B13", cts="A15", dtr="A16", dsr="B14", dcd="B15",
+            attrs=Attrs(IO_STANDARD="SB_LVCMOS", PULLUP=1),
+            role="dce"
         ),
 
         *SPIFlashResources(0,

--- a/nmigen_boards/icestick.py
+++ b/nmigen_boards/icestick.py
@@ -21,7 +21,8 @@ class ICEStickPlatform(LatticeICE40Platform):
 
         UARTResource(0,
             rx="9", tx="8", rts="7", cts="4", dtr="3", dsr="2", dcd="1",
-            attrs=Attrs(IO_STANDARD="SB_LVTTL", PULLUP=1)
+            attrs=Attrs(IO_STANDARD="SB_LVTTL", PULLUP=1),
+            role="dce"
         ),
 
         IrDAResource(0,

--- a/nmigen_boards/nexys4ddr.py
+++ b/nmigen_boards/nexys4ddr.py
@@ -100,8 +100,9 @@ class Nexys4DDRPlatform(Xilinx7SeriesPlatform):
             Attrs(IOSTANDARD="LVCMOS33")),
 
         UARTResource(0,
-            rx="C4", tx="D4", rts="D3", cts="E5",
-            attrs=Attrs(IOSTANDARD="LVCMOS33")),
+            rx="C4", tx="D4", rts="E5", cts="D3",
+            attrs=Attrs(IOSTANDARD="LVCMOS33"),
+            role="dce"),
 
         Resource("ps2_host", 0,
             Subsignal("clk", Pins("F4", dir="i")),

--- a/nmigen_boards/resources/interface.py
+++ b/nmigen_boards/resources/interface.py
@@ -5,22 +5,30 @@ __all__ = ["UARTResource", "IrDAResource", "SPIResource"]
 
 
 def UARTResource(*args, rx, tx, rts=None, cts=None, dtr=None, dsr=None, dcd=None, ri=None,
-                 conn=None, attrs=None):
+                 conn=None, attrs=None, role=None):
+    assert role in ("dce", "dte")
+    if role == "dte":
+        dce_to_dte = "i"
+        dte_to_dce = "o"
+    else:
+        dce_to_dte = "o"
+        dte_to_dce = "i"
+
     io = []
     io.append(Subsignal("rx", Pins(rx, dir="i", conn=conn, assert_width=1)))
     io.append(Subsignal("tx", Pins(tx, dir="o", conn=conn, assert_width=1)))
     if rts is not None:
-        io.append(Subsignal("rts", Pins(rts, dir="o", conn=conn, assert_width=1)))
+        io.append(Subsignal("rts", Pins(rts, dir=dte_to_dce, conn=conn, assert_width=1)))
     if cts is not None:
-        io.append(Subsignal("cts", Pins(cts, dir="i", conn=conn, assert_width=1)))
+        io.append(Subsignal("cts", Pins(cts, dir=dce_to_dte, conn=conn, assert_width=1)))
     if dtr is not None:
-        io.append(Subsignal("dtr", Pins(dtr, dir="o", conn=conn, assert_width=1)))
+        io.append(Subsignal("dtr", Pins(dtr, dir=dte_to_dce, conn=conn, assert_width=1)))
     if dsr is not None:
-        io.append(Subsignal("dsr", Pins(dsr, dir="i", conn=conn, assert_width=1)))
+        io.append(Subsignal("dsr", Pins(dsr, dir=dce_to_dte, conn=conn, assert_width=1)))
     if dcd is not None:
-        io.append(Subsignal("dcd", Pins(dcd, dir="i", conn=conn, assert_width=1)))
+        io.append(Subsignal("dcd", Pins(dcd, dir=dce_to_dte, conn=conn, assert_width=1)))
     if ri is not None:
-        io.append(Subsignal("ri", Pins(ri, dir="i", conn=conn, assert_width=1)))
+        io.append(Subsignal("ri", Pins(ri, dir=dce_to_dte, conn=conn, assert_width=1)))
     if attrs is not None:
         io.append(attrs)
     return Resource.family(*args, default_name="uart", ios=io)


### PR DESCRIPTION
This PR adds 'role' parameter to UARTResource and corrects errors and inconsistencies in UART flow control pin definitions.

* icestick: signal names matched the pin numbers, but directions were reversed. Fix by setting role=dce.
* ice40_hx8h_b_evn: RTS/CTS and DTR/DSR pairs were swapped, compared to the schematic, but the direction of DCD was incorrect. Fix by un-swapping, and setting role=dce.
* blackice: no RTS/CTS signals in the schematic (likely was a copy-paste from blackice_ii?), remove corresponding definitions.
* blackice_ii: pin numbers match CH340G signals, but directions were reversed. Fix by setting role=dce.
* de0: RTS/CTS signals match the schematic, but directions were reversed. Fix by setting role=dce.
* nexys4ddr: RTS/CTS signals were swapped compared to the schematic. Fix by un-swapping and setting role=dce.

Schematic references are mentioned in commit messages.
Closes #63.