### PR TITLE
tinyfpga_axN: use lattice_machxo_2_3l instead of lattice_machxo2

### DIFF
--- a/nmigen_boards/tinyfpga_ax1.py
+++ b/nmigen_boards/tinyfpga_ax1.py
@@ -1,5 +1,5 @@
 from nmigen.build import *
-from nmigen.vendor.lattice_machxo2 import *
+from nmigen.vendor.lattice_machxo_2_3l import *
 from .resources import *
 
 

--- a/nmigen_boards/tinyfpga_ax2.py
+++ b/nmigen_boards/tinyfpga_ax2.py
@@ -1,5 +1,5 @@
 from nmigen.build import *
-from nmigen.vendor.lattice_machxo2 import *
+from nmigen.vendor.lattice_machxo_2_3l import *
 from .resources import *
 
 


### PR DESCRIPTION
With PR https://github.com/nmigen/nmigen/pull/408 file lattice_machxo2.py is renamed lattice_machxo_2_3l.py.
This PR update tinyfpga_axN classes according to that.