### PR TITLE
machXO3_sk: fix platform name

### DIFF
--- a/nmigen_boards/machXO3_sk.py
+++ b/nmigen_boards/machXO3_sk.py
@@ -9,7 +9,7 @@ from .resources import *
 __all__ = ["MachXO3SKPlatform"]
 
 
-class MachXO3SKPlatform(LatticeMachXO2Platform):
+class MachXO3SKPlatform(LatticeMachXO3LPlatform):
     device      = "LCMXO3LF-6900C"
     package     = "BG256"
     speed       = "5"


### PR DESCRIPTION
This board is based on MachXO3L FPGA. So, replace LatticeMachXO2Platform by LatticeMachXO3LPlatform.