### PR TITLE
icebreaker: fix UART flow control pins.

### DIFF
--- a/nmigen_boards/icebreaker.py
+++ b/nmigen_boards/icebreaker.py
@@ -26,7 +26,8 @@ class ICEBreakerPlatform(LatticeICE40Platform):
 
         UARTResource(0,
             rx="6", tx="9",
-            attrs=Attrs(IO_STANDARD="SB_LVTTL", PULLUP=1)
+            attrs=Attrs(IO_STANDARD="SB_LVTTL", PULLUP=1),
+            role="dce"
         ),
 
         *SPIFlashResources(0,


### PR DESCRIPTION
Adds a role attribute to the ICEBreakerPlatform's UARTResource.

Since commit 5d56f7fd584a52f0c5498aa5b8f64c23c805205b all uses of
UARTResource must specify a role attribute. Without this role attribute,
icebreaker.py cannot be imported.