### PR TITLE
orangecrab_r0_2: fix dq pin definitions.

### DIFF
--- a/nmigen_boards/orangecrab_r0_2.py
+++ b/nmigen_boards/orangecrab_r0_2.py
@@ -49,8 +49,8 @@ class OrangeCrabR0_2Platform(LatticeECP5Platform):
             Subsignal("dqs",     DiffPairs("G18 H17", "B15 A16", dir="io"),
                       Attrs(IO_TYPE="SSTL135D_I", TERMINATION="OFF",
                       DIFFRESISTOR="100")),
-            Subsignal("dq",      Pins("C17 D15 B17 C16 A15 B13 A17 A13 F17 F16 G15 F15 J16 C18"
-                                      "H16 F18", dir="io"), Attrs(TERMINATION="75")),
+            Subsignal("dq",      Pins("C17 D15 B17 C16 A15 B13 A17 A13 F17 F16 G15 F15 J16 C18 H16 F18",
+                                      dir="io"), Attrs(TERMINATION="75")),
             Subsignal("dm",      Pins("G16 D16", dir="o")),
             Subsignal("odt",     Pins("C13", dir="o")),
             Attrs(IO_TYPE="SSTL135_I", SLEWRATE="FAST")


### PR DESCRIPTION
This fixes a bad pin definition due to string concatenation with no added space. I figured a long line was better than keeping the split string footgun, but I can redo it with a trailing space if you want to keep to a column width instead.