### PR TITLE
add resource helpers for USB (direct+ULPI)

### DIFF
--- a/nmigen_boards/fomu_hacker.py
+++ b/nmigen_boards/fomu_hacker.py
@@ -23,11 +23,8 @@ class FomuHackerPlatform(LatticeICE40Platform):
             attrs=Attrs(IO_STANDARD="SB_LVCMOS")
         ),
 
-        Resource("usb", 0,
-            Subsignal("d_p", Pins("A4")),
-            Subsignal("d_n", Pins("A2")),
-            Subsignal("pullup", Pins("D5")),
-            Attrs(IO_STANDARD="SB_LVCMOS"),
+        *DirectUSBResource(dp="A4", dn="A2", pullup="D5",
+            attrs=Attrs(IO_STANDARD="SB_LVCMOS"),
         ),
 
         *SPIFlashResources(0,

--- a/nmigen_boards/fomu_pvt.py
+++ b/nmigen_boards/fomu_pvt.py
@@ -23,12 +23,9 @@ class FomuPVTPlatform(LatticeICE40Platform):
             attrs=Attrs(IO_STANDARD="SB_LVCMOS")
         ),
 
-        Resource("usb", 0,
-            Subsignal("d_p", Pins("A1")),
-            Subsignal("d_n", Pins("A2")),
-            Subsignal("pullup", Pins("A4")),
-            Attrs(IO_STANDARD="SB_LVCMOS"),
-        ),
+
+        *DirectUSBResource(dp="A1", dn="A2", pullup="A4",
+                attrs=Attrs(IO_STANDARD="SB_LVCMOS"))
 
         *SPIFlashResources(0,
             cs="C1", clk="D1", copi="F1", cipo="E1",

--- a/nmigen_boards/orangecrab_r0_1.py
+++ b/nmigen_boards/orangecrab_r0_1.py
@@ -64,12 +64,7 @@ class OrangeCrabR0_1Platform(LatticeECP5Platform):
             attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")
         ),
 
-        Resource("usb", 0,
-            Subsignal("d_p",    Pins("N1", dir="io")),
-            Subsignal("d_m",    Pins("M2", dir="io")),
-            Subsignal("pullup", Pins("N2", dir="o")),
-            Attrs(IO_TYPE="LVCMOS33")
-        ),
+        *DirectUSBResource(dp="N1", dn="M2", pullup="N2", attrs=Attrs(IO_TYPE="LVCMOS33"))
     ]
     connectors = [
         Connector("io", 0, {

--- a/nmigen_boards/orangecrab_r0_2.py
+++ b/nmigen_boards/orangecrab_r0_2.py
@@ -76,12 +76,7 @@ class OrangeCrabR0_2Platform(LatticeECP5Platform):
             attrs=Attrs(IO_TYPE="LVCMOS33", SLEWRATE="FAST")
         ),
 
-        Resource("usb", 0,
-            Subsignal("d_p",    Pins("N1", dir="io")),
-            Subsignal("d_m",    Pins("M2", dir="io")),
-            Subsignal("pullup", Pins("N2", dir="o")),
-            Attrs(IO_TYPE="LVCMOS33")
-        ),
+        *DirectUSBResource(dp="N1", dn="M2", pullup="N2", attrs=Attrs(IO_TYPE="LVCMOS33"))
     ]
     connectors = [
         Connector("io", 0, {

--- a/nmigen_boards/resources/interface.py
+++ b/nmigen_boards/resources/interface.py
@@ -1,7 +1,10 @@
 from nmigen.build import *
 
 
-__all__ = ["UARTResource", "IrDAResource", "SPIResource"]
+__all__ = [
+    "UARTResource", "IrDAResource", "SPIResource",
+    "DirectUSBResource", "ULPIResource"
+]
 
 
 def UARTResource(*args, rx, tx, rts=None, cts=None, dtr=None, dsr=None, dcd=None, ri=None,
@@ -81,3 +84,35 @@ def SPIResource(*args, cs, clk, copi, cipo, int=None, reset=None,
     if attrs is not None:
         io.append(attrs)
     return Resource.family(*args, default_name="spi", ios=io)
+
+
+def DirectUSBResource(*args, dp, dn, pullup=None, vbus_valid=None,
+    conn=None, attrs=None):
+
+    io = []
+    io.append(Subsignal("d_p", Pins(dp, dir="io", conn=conn, assert_width=1)))
+    io.append(Subsignal("d_n", Pins(dn, dir="io", conn=conn, assert_width=1)))
+    if pullup:
+        io.append(Subsignal("pullup", Pins(pullup, dir="o", conn=conn, assert_width=1)))
+    if vbus_valid:
+        io.append(Subsignal("vbus_valid", Pins(pullup, dir="i", conn=conn, assert_width=1)))
+    if attrs is not None:
+        io.append(attrs)
+    return Resource.family(*args, default_name="usb", ios=io)
+
+
+def ULPIResource(*args, data, clk, dir, nxt, stp, rst=None,
+            clk_out=False, attrs=None, conn=None):
+    clock_dir = "o" if clk_out else "i"
+
+    io = []
+    io.append(Subsignal("data", Pins(data, dir="io", conn=conn, assert_width=8)))
+    io.append(Subsignal("clk", Pins(clk, dir=clock_dir, conn=conn, assert_width=1)))
+    io.append(Subsignal("dir", Pins(dir, dir="i", conn=conn, assert_width=1)))
+    io.append(Subsignal("nxt", Pins(nxt, dir="i", conn=conn, assert_width=1)))
+    io.append(Subsignal("stp", Pins(stp, dir="o", conn=conn, assert_width=1)))
+    if rst is not None:
+        io.append(Subsignal("rst", Pins(stp, dir="o", conn=conn, assert_width=1)))
+    if attrs is not None:
+        io.append(attrs)
+    return Resource.family(*args, default_name="usb", ios=io)

--- a/nmigen_boards/tinyfpga_bx.py
+++ b/nmigen_boards/tinyfpga_bx.py
@@ -19,11 +19,8 @@ class TinyFPGABXPlatform(LatticeICE40Platform):
 
         *LEDResources(pins="B3", attrs=Attrs(IO_STANDARD="SB_LVCMOS")),
 
-        Resource("usb", 0,
-            Subsignal("d_p",    Pins("B4", dir="io")),
-            Subsignal("d_n",    Pins("A4", dir="io")),
-            Subsignal("pullup", Pins("A3", dir="o")),
-            Attrs(IO_STANDARD="SB_LVCMOS")
+        *DirectUSBResource(dp="B4", dn="A4", pullup="A3",
+            attrs=Attrs(IO_STANDARD="SB_LVCMOS")
         ),
 
         *SPIFlashResources(0,


### PR DESCRIPTION
These resource helpers are in the format accepted by e.g. LUNA, and should help to standardize USB pin naming. :)