### PR TITLE
CI: Setup github actions 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,13 @@
+on: [push, pull_request]
+name: CI
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+      - name: Test
+        run: |
+          python setup.py test


### PR DESCRIPTION
This should atleast catch trivial typos like #83 and #87.

Currently `nmigen-boards` requires a unreleased version of `nmigen`, so I am manually installing it from git.