### PR TITLE
Convert OrangeCrab r0.2 ADC sense to diffpair

### DIFF
--- a/nmigen_boards/orangecrab_r0_2.py
+++ b/nmigen_boards/orangecrab_r0_2.py
@@ -66,7 +66,7 @@ class OrangeCrabR0_2Platform(LatticeECP5Platform):
         Resource("adc", 0,
             Subsignal("ctrl",     Pins("G1 F1", dir="o")),
             Subsignal("mux",      Pins("F4 F3 F2 H1", dir="o")),
-            Subsignal("sense", Pins("H3", dir="i"), Attrs(IO_TYPE="LVCMOS33D"))
+            Subsignal("sense",    DiffPair("H3", "G3", dir="i")),
             Attrs(IO_TYPE="LVCMOS33")
         ),
 

--- a/nmigen_boards/orangecrab_r0_2.py
+++ b/nmigen_boards/orangecrab_r0_2.py
@@ -66,8 +66,7 @@ class OrangeCrabR0_2Platform(LatticeECP5Platform):
         Resource("adc", 0,
             Subsignal("ctrl",     Pins("G1 F1", dir="o")),
             Subsignal("mux",      Pins("F4 F3 F2 H1", dir="o")),
-            Subsignal("sense_hi", Pins("H3", dir="i")),
-            Subsignal("sense_lo", Pins("G3", dir="i")),
+            Subsignal("sense", Pins("H3", dir="i"), Attrs(IO_TYPE="LVCMOS33D"))
             Attrs(IO_TYPE="LVCMOS33")
         ),
 


### PR DESCRIPTION
The OrangeCrab ADC utilizes the comparator in the ECP5 A/B pair to do level sensing. This requires "sense_hi"/"sense_lo" to be configured as a diff pair. Consolidate "sense_hi"/"sense_lo" into a diff pair "sense".