### PR TITLE
Fix OC r0.2 ADC diffpair

### DIFF
--- a/nmigen_boards/orangecrab_r0_2.py
+++ b/nmigen_boards/orangecrab_r0_2.py
@@ -66,7 +66,7 @@ class OrangeCrabR0_2Platform(LatticeECP5Platform):
         Resource("adc", 0,
             Subsignal("ctrl",     Pins("G1 F1", dir="o")),
             Subsignal("mux",      Pins("F4 F3 F2 H1", dir="o")),
-            Subsignal("sense",    DiffPair("H3", "G3", dir="i")),
+            Subsignal("sense",    DiffPairs("H3", "G3", dir="i"), Attrs(IO_TYPE="LVCMOS33D")),
             Attrs(IO_TYPE="LVCMOS33")
         ),
 


### PR DESCRIPTION
Accidentally merged in OrangeCrab r0.2 board file with broken ADC sense DiffPair. Fixed and tested with my ADC sketch.