### PR TITLE
resources: allow use of ULPI PHYs with active-low RST pins

### DIFF
--- a/nmigen_boards/resources/interface.py
+++ b/nmigen_boards/resources/interface.py
@@ -102,7 +102,7 @@ def DirectUSBResource(*args, d_p, d_n, pullup=None, vbus_valid=None,
 
 
 def ULPIResource(*args, data, clk, dir, nxt, stp, rst=None,
-            clk_dir='i', attrs=None, conn=None):
+            clk_dir='i', rst_invert=False, attrs=None, conn=None):
     assert clk_dir in ('i', 'o',)
 
     io = []
@@ -112,7 +112,8 @@ def ULPIResource(*args, data, clk, dir, nxt, stp, rst=None,
     io.append(Subsignal("nxt", Pins(nxt, dir="i", conn=conn, assert_width=1)))
     io.append(Subsignal("stp", Pins(stp, dir="o", conn=conn, assert_width=1)))
     if rst is not None:
-        io.append(Subsignal("rst", Pins(stp, dir="o", conn=conn, assert_width=1)))
+        io.append(Subsignal("rst", Pins(rst, dir="o", invert=rst_invert,
+            conn=conn, assert_width=1)))
     if attrs is not None:
         io.append(attrs)
     return Resource.family(*args, default_name="usb", ios=io)


### PR DESCRIPTION
Didn't foresee this when creating the resources: PHYs like the USB3343 have an active-low RST instead of the more typical active-high. Adding a parameter for that.

Also, fixes a typo that affected PHYs with `rst` specified (😳 ).