### PR TITLE
ecpix5: add termination attributes to DDR3 signals

### DIFF
--- a/nmigen_boards/ecpix5.py
+++ b/nmigen_boards/ecpix5.py
@@ -68,8 +68,10 @@ class _ECPIX5Platform(LatticeECP5Platform):
             Subsignal("cas",    PinsN("P2", dir="o")),
             Subsignal("a",      Pins("T5 M3 L3 V6 K2 W6 K3 L1 H2 L2 N1 J1 M1 K1", dir="o")),
             Subsignal("ba",     Pins("U6 N3 N4", dir="o")),
-            Subsignal("dqs",    DiffPairs("V4 V1", "U5 U2", dir="io"), Attrs(IO_TYPE="SSTL135D_I", TERMINATION="OFF", DIFFRESISTOR="100")),
-            Subsignal("dq",     Pins("T4 W4 R4 W5 R6 P6 P5 P4 R1 W3 T2 V3 U3 W1 T1 W2", dir="io"), Attrs(TERMINATION="75")),
+            Subsignal("dqs",    DiffPairs("V4 V1", "U5 U2", dir="io"),
+                                Attrs(IO_TYPE="SSTL135D_I", TERMINATION="OFF", DIFFRESISTOR="100")),
+            Subsignal("dq",     Pins("T4 W4 R4 W5 R6 P6 P5 P4 R1 W3 T2 V3 U3 W1 T1 W2", dir="io"),
+                                Attrs(TERMINATION="75")),
             Subsignal("dm",     Pins("U4 U1", dir="o")),
             Subsignal("odt",    Pins("P3", dir="o")),
             Attrs(IO_TYPE="SSTL135_I")

--- a/nmigen_boards/ecpix5.py
+++ b/nmigen_boards/ecpix5.py
@@ -68,8 +68,8 @@ class _ECPIX5Platform(LatticeECP5Platform):
             Subsignal("cas",    PinsN("P2", dir="o")),
             Subsignal("a",      Pins("T5 M3 L3 V6 K2 W6 K3 L1 H2 L2 N1 J1 M1 K1", dir="o")),
             Subsignal("ba",     Pins("U6 N3 N4", dir="o")),
-            Subsignal("dqs",    DiffPairs("V4 V1", "U5 U2", dir="io"), Attrs(IO_TYPE="SSTL135D_I")),
-            Subsignal("dq",     Pins("T4 W4 R4 W5 R6 P6 P5 P4 R1 W3 T2 V3 U3 W1 T1 W2", dir="io")),
+            Subsignal("dqs",    DiffPairs("V4 V1", "U5 U2", dir="io"), Attrs(IO_TYPE="SSTL135D_I", TERMINATION="OFF", DIFFRESISTOR="100")),
+            Subsignal("dq",     Pins("T4 W4 R4 W5 R6 P6 P5 P4 R1 W3 T2 V3 U3 W1 T1 W2", dir="io"), Attrs(TERMINATION="75")),
             Subsignal("dm",     Pins("U4 U1", dir="o")),
             Subsignal("odt",    Pins("P3", dir="o")),
             Attrs(IO_TYPE="SSTL135_I")


### PR DESCRIPTION
Those attributes were present in the LiteX platform file and should be added to nmigen-boards for better signal integrity.