### PR TITLE
Add OLED connector to ulx3s.py

### DIFF
--- a/nmigen_boards/ulx3s.py
+++ b/nmigen_boards/ulx3s.py
@@ -96,11 +96,12 @@ class _ULX3SPlatform(LatticeECP5Platform):
         ),
         
         # OLED connector
-        Resource("oled_clk",  0, Pins("P4", dir="o"), Attrs(IO_TYPE="LVCMOS33", DRIVE="4", PULLMODE="UP")),
-        Resource("oled_mosi", 0, Pins("P3", dir="o"), Attrs(IO_TYPE="LVCMOS33", DRIVE="4", PULLMODE="UP")),
-        Resource("oled_dc",   0, Pins("P1", dir="o"), Attrs(IO_TYPE="LVCMOS33", DRIVE="4", PULLMODE="UP")),
-        Resource("oled_resn", 0, Pins("P2", dir="o"), Attrs(IO_TYPE="LVCMOS33", DRIVE="4", PULLMODE="UP")),
-        Resource("oled_csn",  0, Pins("N2", dir="o"), Attrs(IO_TYPE="LVCMOS33", DRIVE="4", PULLMODE="UP")),
+        SPIResource(0,
+            cs="N2", clk="P4", copi="P3", cipo=None, reset="P2",
+            attrs=Attrs(IO_TYPE="LVCMOS33", DRIVE="4", PULLMODE="UP")),
+        Resource("oled", 0,
+            Subsignal("dc", Pins("P1", dir="o"),
+                Attrs(IO_TYPE="LVCMOS33", DRIVE="4", PULLMODE="UP"))),
 
         # PCB antenna, tuned to 433MHz
         Resource("ant", 0, Pins("G1", dir="o"), Attrs(IO_TYPE="LVCMOS33")),

--- a/nmigen_boards/ulx3s.py
+++ b/nmigen_boards/ulx3s.py
@@ -94,6 +94,13 @@ class _ULX3SPlatform(LatticeECP5Platform):
             Subsignal("gpio17", Pins("N3"),          Attrs(PULLMODE="UP")),
             Attrs(IO_TYPE="LVCMOS33", DRIVE="4")
         ),
+        
+        # OLED connector
+        Resource("oled_clk",  0, Pins("P4", dir="o"), Attrs(IO_TYPE="LVCMOS33", DRIVE="4", PULLMODE="UP")),
+        Resource("oled_mosi", 0, Pins("P3", dir="o"), Attrs(IO_TYPE="LVCMOS33", DRIVE="4", PULLMODE="UP")),
+        Resource("oled_dc",   0, Pins("P1", dir="o"), Attrs(IO_TYPE="LVCMOS33", DRIVE="4", PULLMODE="UP")),
+        Resource("oled_resn", 0, Pins("P2", dir="o"), Attrs(IO_TYPE="LVCMOS33", DRIVE="4", PULLMODE="UP")),
+        Resource("oled_csn",  0, Pins("N2", dir="o"), Attrs(IO_TYPE="LVCMOS33", DRIVE="4", PULLMODE="UP")),
 
         # PCB antenna, tuned to 433MHz
         Resource("ant", 0, Pins("G1", dir="o"), Attrs(IO_TYPE="LVCMOS33")),


### PR DESCRIPTION
This adds the OLED connector pins to the ULX3S platform. The constraints were taken from https://github.com/emard/ulx3s-misc/blob/master/constraints/ulx3s_v20.lpf