### PR TITLE
Use correct IO attribute for ECP5 FPGAs

### DIFF
--- a/nmigen_boards/ecp5_5g_evn.py
+++ b/nmigen_boards/ecp5_5g_evn.py
@@ -71,7 +71,7 @@ class ECP55GEVNPlatform(LatticeECP5Platform):
 
         *SPIFlashResources(0,
             cs="R2", clk="U3", cipo="V2", copi="W2", wp="Y2", hold="W1",
-            attrs=Attrs(IO_STANDARD="LVCMOS33")
+            attrs=Attrs(IO_TYPE="LVCMOS33")
         ),
 
         Resource("serdes", 0,

--- a/nmigen_boards/ulx3s.py
+++ b/nmigen_boards/ulx3s.py
@@ -26,12 +26,12 @@ class _ULX3SPlatform(LatticeECP5Platform):
         Resource("program", 0, PinsN("M4", dir="o"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")),
 
         *LEDResources(pins="B2 C2 C1 D2 D1 E2 E1 H3",
-            attrs=Attrs(IO_STANDARD="LVCMOS33", DRIVE="4")),
+            attrs=Attrs(IO_TYPE="LVCMOS33", DRIVE="4")),
         *ButtonResources(pins="R1 T1 R18 V1 U1 H16",
-            attrs=Attrs(IO_STANDARD="LVCMOS33", PULLMODE="DOWN")
+            attrs=Attrs(IO_TYPE="LVCMOS33", PULLMODE="DOWN")
         ),
         *ButtonResources("switch", pins="E8 D8 D7 E7",
-            attrs=Attrs(IO_STANDARD="LVCMOS33", PULLMODE="DOWN")
+            attrs=Attrs(IO_TYPE="LVCMOS33", PULLMODE="DOWN")
         ),
 
         # Semantic aliases by button label.

--- a/nmigen_boards/versa_ecp5.py
+++ b/nmigen_boards/versa_ecp5.py
@@ -56,7 +56,7 @@ class VersaECP5Platform(LatticeECP5Platform):
 
         *SPIFlashResources(0,
             cs="R2", clk="U3", cipo="W2", copi="V2", wp="Y2", hold="W1",
-            attrs=Attrs(IO_STANDARD="LVCMOS33")
+            attrs=Attrs(IO_TYPE="LVCMOS33")
         ),
 
         Resource("eth_clk125",     0, Pins("L19", dir="i"),


### PR DESCRIPTION
This changes several incorrect IO_STANDARD attributes to IO_TYPE.

Signed-off-by: Oguz Meteer <info@guztech.nl>