### PR TITLE
fixed PMOD 1 (JB) connections 7-10

### DIFF
--- a/nmigen_boards/arty_z7.py
+++ b/nmigen_boards/arty_z7.py
@@ -70,7 +70,7 @@ class ArtyZ720Platform(Xilinx7SeriesPlatform):
     ]
     connectors = [
         Connector("pmod", 0, "Y18 Y19 Y16 Y17 - - U18 U19 W18 W19 - -"),  # JA
-        Connector("pmod", 1, "Y14 W14 T10 T11 - - W16 V16 W13 V12 - -"),  # JB
+        Connector("pmod", 1, "Y14 W14 T10 T11 - - V16 W16 V12 W13 - -"),  # JB
 
         Connector("ck_io", 0, {
             # Outer Digital Header

--- a/nmigen_boards/arty_z7.py
+++ b/nmigen_boards/arty_z7.py
@@ -70,7 +70,7 @@ class ArtyZ720Platform(Xilinx7SeriesPlatform):
     ]
     connectors = [
         Connector("pmod", 0, "Y18 Y19 Y16 Y17 - - U18 U19 W18 W19 - -"),  # JA
-        Connector("pmod", 1, "Y14 W14 T10 T11 - - V16 W16 V12 W13 - -"),  # JB
+        Connector("pmod", 1, "W14 Y14 T11 T10 - - V16 W16 V12 W13 - -"),  # JB
 
         Connector("ck_io", 0, {
             # Outer Digital Header


### PR DESCRIPTION
fixed those values after checking the official schematics for the arty z7 board

https://reference.digilentinc.com/learn/documentation/schematics/arty-z7-schematic

please check to confirm. the new version works for me, however there might be an oversight I did not notice. this PMOD port is called JB in the schematics.