### PR TITLE
Arty S7 OpenOCD Support

### DIFF
--- a/nmigen_boards/arty_s7.py
+++ b/nmigen_boards/arty_s7.py
@@ -6,7 +6,7 @@ from nmigen.vendor.xilinx_7series import *
 from .resources import *
 
 
-__all__ = ["ArtysS7_25Platform", "ArtyS7_50Platform"]
+__all__ = ["ArtyS7_25Platform", "ArtyS7_50Platform"]
 
 
 class _ArtyS7Platform(Xilinx7SeriesPlatform):


### PR DESCRIPTION
This PR does two things:

1. Fixes a typo that prevented the import `from nmigen_boards.arty_s7 import *` from working properly.
2. Adds support for the `openocd` programmer for the Arty S7 board.

I kept in mind your [comments](https://github.com/nmigen/nmigen/issues/428) re: OpenOCD and programmers in general when writing this PR. So perhaps consider it a litmus test to supporting more than one programmer in nmigen :):

>I looked at the openocd invocations currently in nmigen-boards. All of them are different, pretty significantly so. 

Indeed, all the `openocd` invocations are different, and this one's no exception. One difference is that I use the upstream board config file since it's available already (I committed it in mid 2018). Another difference is that I support both JTAG programming and flashing via a proxy.

>We can just decide on what to do here. For example, we can decide that on every board with multiple ways to program it, toolchain_program takes a programmer="<tool>" keyword argument.

I went ahead and used this suggestion as-is.

>toolchain_program should be configurable enough, and just enough, to cover the most typical use cases.

In addition, I added a `flash` keyword argument that lets the user choose between JTAG programming and flashing a bitstream. JTAG programming is _noticeably_ faster, shortening the already long "write, compile, program" feedback loop. Hopefully at some point Vivado's time can be shaved off too :). Therefore I think this is a reasonable keyword argument to add that will cover most use cases. I don't know if `vivado`'s programmer has an equivalent.



