### PR TITLE
ulx3s: correct speed grade.

### DIFF
--- a/nmigen_boards/ulx3s.py
+++ b/nmigen_boards/ulx3s.py
@@ -16,7 +16,7 @@ __all__ = [
 
 class _ULX3SPlatform(LatticeECP5Platform):
     package                = "BG381"
-    speed                  = "8"
+    speed                  = "6"
     default_clk            = "clk25"
 
     resources = [


### PR DESCRIPTION
The boards available on the crowdsupply page, as well as my
hand-built board, all seem to use speed grade 6.