### PR TITLE
Add quickfeather board

### DIFF
--- a/nmigen_boards/quickfeather.py
+++ b/nmigen_boards/quickfeather.py
@@ -1,0 +1,95 @@
+import os
+import sys
+import subprocess
+
+from nmigen.build import *
+from nmigen.vendor.quicklogic import *
+from nmigen_boards.resources import *
+
+
+__all__ = ["QuickfeatherPlatform"]
+
+
+class QuickfeatherPlatform(QuicklogicPlatform):
+    device      = "ql-eos-s3_wlcsp"
+    package     = "PU64"
+    default_clk = "sys_clk0"
+    connectors = [
+        Connector("J", 2, "- 28 22 21 37 36 42 40 7 2 4 5"),
+        Connector("J", 3, "- 8 9 17 16 20 6 55 31 25 47 - - - - 41"),
+        Connector("J", 8, "27 26 33 32 23 57 56 3 64 62 63 61 59 - - -"),
+    ]
+    resources   = [
+        # This is a placeholder resource since the board utilizes
+        # default internal SoC clock.
+        Resource("sys_clk0", 0, Pins("63", dir="i"), Clock(60e6)),
+
+        *ButtonResources(pins="62"),
+
+        RGBLEDResource(0, r="34", g="39", b="38"),
+
+        UARTResource(0,
+            rx="9", tx="8",
+        ),
+
+        SPIResource(0,
+            cs="11", clk="20", copi="16", cipo="17"
+        ),
+        SPIResource(1,
+            cs="37", clk="40", copi="36", cipo="42",
+            role="peripheral"
+        ),
+
+        I2CResource(0,
+            scl="4", sda="5"
+        ),
+        I2CResource(1,
+            scl="22", sda="21"
+        ),
+
+        DirectUSBResource(0, d_p="10", d_n="14"),
+
+        Resource("swd", 0,
+            Subsignal("clk", Pins("54", dir="io")),
+            Subsignal("io",  Pins("53", dir="io")),
+        ),
+    ]
+
+    # This programmer requires OpenOCD with support for eos-s3:
+    # https://github.com/antmicro/openocd/tree/eos-s3-support
+    def toolchain_program(self, products, name):
+        openocd = os.environ.get("OPENOCD", "openocd")
+        with products.extract("{}.bit".format(name)) as bitstream_filename:
+            bitstream_folder = os.path.dirname(bitstream_filename)
+            top_ocd_path = os.path.join(bitstream_folder, "top.openocd")
+            subprocess.call([sys.executable, "-m",
+                             "quicklogic_fasm.bitstream_to_openocd",
+                             bitstream_filename, top_ocd_path])
+            # Merge IOMUX config with bitstream into one OpenOCD script
+            with products.extract("{}_iomux.openocd".format(name)) as iomux_filename:
+                merged_ocd_cfg = str()
+                merged_ocd_cfg_path = os.path.join(bitstream_folder, 'top_and_iomux.openocd')
+                with open(top_ocd_path, "r") as top_file:
+                    merged_ocd_cfg = top_file.read()[0:-2]
+                with open(iomux_filename, "r") as iomux_file:
+                    merged_ocd_cfg += iomux_file.read() + '}'
+                with open(merged_ocd_cfg_path, "w") as merged_ocd_cfg_file:
+                    merged_ocd_cfg_file.write(merged_ocd_cfg)
+                cfg_path = merged_ocd_cfg_path
+            try:
+                openocd_proc = subprocess.Popen([openocd, "-s", "tcl",
+                                                 "-f", "interface/ftdi/antmicro-ftdi-adapter.cfg",
+                                                 "-f", "interface/ftdi/swd-resistor-hack.cfg",
+                                                 "-f", "board/quicklogic_quickfeather.cfg",
+                                                 "-f", cfg_path,
+                                                 "-c", "init",
+                                                 "-c", "reset halt",
+                                                 "-c", "load_bitstream",
+                                                 "-c", "exit"])
+            except Exception as e:
+                openocd_proc.kill()
+                raise e
+
+if __name__ == "__main__":
+    from .test.blinky import *
+    QuickfeatherPlatform().build(Blinky(), do_program=False)

--- a/nmigen_boards/quickfeather.py
+++ b/nmigen_boards/quickfeather.py
@@ -14,16 +14,16 @@ class QuickfeatherPlatform(QuicklogicPlatform):
     device      = "ql-eos-s3_wlcsp"
     package     = "PU64"
     default_clk = "sys_clk0"
+    # It is possible to configure both oscillator frequency and
+    # clock divider. Resulting frequency is: 60MHz / 12 = 5MHz
+    osc_freq    = int(60e6)
+    osc_div     = 12
     connectors = [
         Connector("J", 2, "- 28 22 21 37 36 42 40 7 2 4 5"),
         Connector("J", 3, "- 8 9 17 16 20 6 55 31 25 47 - - - - 41"),
         Connector("J", 8, "27 26 33 32 23 57 56 3 64 62 63 61 59 - - -"),
     ]
     resources   = [
-        # This is a placeholder resource since the board utilizes
-        # default internal SoC clock.
-        Resource("sys_clk0", 0, Pins("63", dir="i"), Clock(60e6)),
-
         *ButtonResources(pins="62"),
 
         RGBLEDResource(0, r="34", g="39", b="38"),


### PR DESCRIPTION
This PR introduces two boards which utilize the QuickLogic EOS-S3 platform: https://github.com/nmigen/nmigen/pull/504
The contents are:
- support for QuickFeather board
- support for programming the bitstream using OpenOCD