### PR TITLE
ci: Install nMigen from git

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install wheel
+          pip install git+https://github.com/nmigen/nmigen
       - name: Test
         run: |
           python setup.py test


### PR DESCRIPTION
I noticed that the CI job was failing because a board file requires a newer nMigen version than then one currently published on PyPI.

This is one way of working around the issue. I can see why one may want to test together with the package from PyPI, so please close this PR if that's the case.