### PR TITLE
Change signal names to match polarity

### DIFF
--- a/nmigen_boards/alchitry_au.py
+++ b/nmigen_boards/alchitry_au.py
@@ -42,13 +42,13 @@ class AlchitryAuPlatform(Xilinx7SeriesPlatform):
 
         # TODO: This is untested
         Resource("ddr3", 0,
-            Subsignal("rst",     PinsN("D13", dir="o")),
+            Subsignal("rst_n",   PinsN("D13", dir="o")),
             Subsignal("clk",     DiffPairs("G14", "F14", dir="o"), Attrs(IOSTANDARD="LVDS")),
             Subsignal("clk_en",  Pins("D15", dir="o")),
-            Subsignal("cs",      PinsN("D16", dir="o")),
-            Subsignal("we",      PinsN("E11", dir="o")),
-            Subsignal("ras",     PinsN("D11", dir="o")),
-            Subsignal("cas",     PinsN("D14", dir="o")),
+            Subsignal("cs_n",    PinsN("D16", dir="o")),
+            Subsignal("we_n",    PinsN("E11", dir="o")),
+            Subsignal("ras_n",   PinsN("D11", dir="o")),
+            Subsignal("cas_n",   PinsN("D14", dir="o")),
             Subsignal("a",       Pins("F12 G16 G15 E16 H11 G12 H16 H12 H16 H13 E12 H14 F13 J15", dir="o")),
             Subsignal("ba",      Pins("E13 F15 E15", dir="o")),
             Subsignal("dqs",     DiffPairs("B15 A15", "B9 A10", dir="io"), Attrs(IOSTANDARD="LVDS")),

--- a/nmigen_boards/arty_a7.py
+++ b/nmigen_boards/arty_a7.py
@@ -14,11 +14,11 @@ class ArtyA7Platform(Xilinx7SeriesPlatform):
     package     = "csg324"
     speed       = "1L"
     default_clk = "clk100"
-    default_rst = "rst"
+    default_rst = "rst_n"
     resources   = [
         Resource("clk100", 0, Pins("E3", dir="i"),
                  Clock(100e6), Attrs(IOSTANDARD="LVCMOS33")),
-        Resource("rst", 0, PinsN("C2", dir="i"), Attrs(IOSTANDARD="LVCMOS33")),
+        Resource("rst_n", 0, PinsN("C2", dir="i"), Attrs(IOSTANDARD="LVCMOS33")),
 
         *LEDResources(pins="H5 J5 T9 T10", attrs=Attrs(IOSTANDARD="LVCMOS33")),
 
@@ -54,13 +54,13 @@ class ArtyA7Platform(Xilinx7SeriesPlatform):
         ),
 
         Resource("ddr3", 0,
-            Subsignal("rst",    PinsN("K6", dir="o")),
+            Subsignal("rst_n",  PinsN("K6", dir="o")),
             Subsignal("clk",    DiffPairs("U9", "V9", dir="o"), Attrs(IOSTANDARD="DIFF_SSTL135")),
             Subsignal("clk_en", Pins("N5", dir="o")),
-            Subsignal("cs",     PinsN("U8", dir="o")),
-            Subsignal("we",     PinsN("P5", dir="o")),
-            Subsignal("ras",    PinsN("P3", dir="o")),
-            Subsignal("cas",    PinsN("M4", dir="o")),
+            Subsignal("cs_n",   PinsN("U8", dir="o")),
+            Subsignal("we_n",   PinsN("P5", dir="o")),
+            Subsignal("ras_n",  PinsN("P3", dir="o")),
+            Subsignal("cas_n",  PinsN("M4", dir="o")),
             Subsignal("a",      Pins("R2 M6 N4 T1 N6 R7 V6 U7 R8 V7 R6 U6 T6 T8", dir="o")),
             Subsignal("ba",     Pins("R1 P4 P2", dir="o")),
             Subsignal("dqs",    DiffPairs("N2 U2", "N1 V2", dir="io"),
@@ -77,7 +77,7 @@ class ArtyA7Platform(Xilinx7SeriesPlatform):
         Resource("eth_clk50", 0, Pins("G18", dir="o"),
                  Clock(50e6), Attrs(IOSTANDARD="LVCMOS33")),
         Resource("eth_mii", 0,
-            Subsignal("rst",     PinsN("C16", dir="o")),
+            Subsignal("rst_n",   PinsN("C16", dir="o")),
             Subsignal("mdio",    Pins("K13", dir="io")),
             Subsignal("mdc",     Pins("F16", dir="o")),
             Subsignal("tx_clk",  Pins("H16", dir="i")),
@@ -92,7 +92,7 @@ class ArtyA7Platform(Xilinx7SeriesPlatform):
             Attrs(IOSTANDARD="LVCMOS33")
         ),
         Resource("eth_rmii", 0,
-            Subsignal("rst",       PinsN("C16", dir="o")),
+            Subsignal("rst_n",     PinsN("C16", dir="o")),
             Subsignal("mdio",      Pins("K13", dir="io")),
             Subsignal("mdc",       Pins("F16", dir="o")),
             Subsignal("tx_en",     Pins("H15", dir="o")),

--- a/nmigen_boards/arty_s7.py
+++ b/nmigen_boards/arty_s7.py
@@ -14,11 +14,11 @@ class _ArtyS7Platform(Xilinx7SeriesPlatform):
     package     = "csga324"
     speed       = "1"
     default_clk = "clk100"
-    default_rst = "rst"
+    default_rst = "rst_n"
     resources   = [
         Resource("clk100", 0, Pins("R2", dir="i"),
                  Clock(100e6), Attrs(IOSTANDARD="SSTL135")),
-        Resource("rst", 0, PinsN("C18", dir="i"), Attrs(IOSTANDARD="LVCMOS33")),
+        Resource("rst_n", 0, PinsN("C18", dir="i"), Attrs(IOSTANDARD="LVCMOS33")),
 
         *LEDResources(pins="E18 F13 E13 H15", attrs=Attrs(IOSTANDARD="LVCMOS33")),
 

--- a/nmigen_boards/arty_z7.py
+++ b/nmigen_boards/arty_z7.py
@@ -38,8 +38,8 @@ class ArtyZ720Platform(Xilinx7SeriesPlatform):
             attrs=Attrs(IOSTANDARD="LVCMOS33")),
 
         Resource("audio", 0,
-            Subsignal("pwm", Pins("R18", dir="o")),
-            Subsignal("sd",  PinsN("T17", dir="o")),
+            Subsignal("pwm",  Pins("R18", dir="o")),
+            Subsignal("sd_n", PinsN("T17", dir="o")),
             Attrs(IOSTANDARD="LVCMOS33")),
 
         Resource("crypto_sda", 0,                               # ATSHA204A
@@ -58,14 +58,14 @@ class ArtyZ720Platform(Xilinx7SeriesPlatform):
             Attrs(IOSTANDARD="LVCMOS33")),
 
         Resource("hdmi_tx", 0,                                  # J11
-            Subsignal("cec", Pins("G15", dir="io")),
-            Subsignal("clk", DiffPairs("L16", "L17", dir="o"),
+            Subsignal("cec",   Pins("G15", dir="io")),
+            Subsignal("clk",   DiffPairs("L16", "L17", dir="o"),
                 Attrs(IOSTANDARD="TMDS_33")),
-            Subsignal("d",   DiffPairs("K17 K19 J18", "K18 J19 H18", dir="o"),
+            Subsignal("d",     DiffPairs("K17 K19 J18", "K18 J19 H18", dir="o"),
                 Attrs(IOSTANDARD="TMDS_33")),
-            Subsignal("hpd", PinsN("R19", dir="i")),
-            Subsignal("scl", Pins("M17", dir="io")),
-            Subsignal("sda", Pins("M18", dir="io")),
+            Subsignal("hpd_n", PinsN("R19", dir="i")),
+            Subsignal("scl",   Pins("M17", dir="io")),
+            Subsignal("sda",   Pins("M18", dir="io")),
             Attrs(IOSTANDARD="LVCMOS33"))
     ]
     connectors = [

--- a/nmigen_boards/atlys.py
+++ b/nmigen_boards/atlys.py
@@ -27,9 +27,9 @@ class AtlysPlatform(XilinxSpartan6Platform):
         return "LVCMOS25" if self._JP12 == "2V5" else "LVCMOS33"
 
     default_clk = "clk100"
-    default_rst = "rst"
+    default_rst = "rst_n"
     resources   = [
-        Resource("rst",    0, PinsN("T15", dir="i"), Attrs(IOSTANDARD=bank2_iostandard)), # RESET
+        Resource("rst_n",  0, PinsN("T15", dir="i"), Attrs(IOSTANDARD=bank2_iostandard)), # RESET
         Resource("clk100", 0, Pins("L15",  dir="i"),
                  Clock(100e6), Attrs(IOSTANDARD="LVCMOS33")),                             # GCLK
 
@@ -79,9 +79,9 @@ class AtlysPlatform(XilinxSpartan6Platform):
             Subsignal("clk",    DiffPairs("G3", "G1", dir="o"),
                                 Attrs(IOSTANDARD="DIFF_SSTL18_II", IN_TERM="NONE")),
             Subsignal("clk_en", Pins("H7", dir="o")),
-            Subsignal("we",     PinsN("E3", dir="o")),
-            Subsignal("ras",    PinsN("L5", dir="o")),
-            Subsignal("cas",    PinsN("K5", dir="o")),
+            Subsignal("we_n",   PinsN("E3", dir="o")),
+            Subsignal("ras_n",  PinsN("L5", dir="o")),
+            Subsignal("cas_n",  PinsN("K5", dir="o")),
             Subsignal("a",      Pins("J7 J6 H5 L7 F3 H4 H3 H6 D2 D1 F4 D3 G6", dir="o")),
             Subsignal("ba",     Pins("F2 F1 E1", dir="o")),
             Subsignal("dqs",    DiffPairs("P2 L4", "P1 L3", dir="o"),
@@ -93,8 +93,8 @@ class AtlysPlatform(XilinxSpartan6Platform):
         ),
 
         Resource("eth_gmii", 0,
-            Subsignal("rst",     PinsN("G13", dir="o")),
-            Subsignal("int",     PinsN("L16", dir="o")),
+            Subsignal("rst_n",   PinsN("G13", dir="o")),
+            Subsignal("int_n",   PinsN("L16", dir="o")),
             Subsignal("mdio",    Pins("N17", dir="io")),
             Subsignal("mdc",     Pins("F16", dir="o")), # Max 8.3MHz
             Subsignal("gtx_clk", Pins("L12", dir="o")),
@@ -111,8 +111,8 @@ class AtlysPlatform(XilinxSpartan6Platform):
             Attrs(IOSTANDARD="LVCMOS33")
         ),
         Resource("eth_rgmii", 0,
-            Subsignal("rst",     PinsN("G13", dir="o")),
-            Subsignal("int",     PinsN("L16", dir="o")),
+            Subsignal("rst_n",   PinsN("G13", dir="o")),
+            Subsignal("int_n",   PinsN("L16", dir="o")),
             Subsignal("mdio",    Pins("N17", dir="io")),
             Subsignal("mdc",     Pins("F16", dir="o")), # Max 8.3MHz
             Subsignal("tx_clk",  Pins("L12", dir="o")),
@@ -124,8 +124,8 @@ class AtlysPlatform(XilinxSpartan6Platform):
             Attrs(IOSTANDARD="LVCMOS33")
         ),
         Resource("eth_mii", 0,
-            Subsignal("rst",     PinsN("G13", dir="o")),
-            Subsignal("int",     PinsN("L16", dir="o")),
+            Subsignal("rst_n",   PinsN("G13", dir="o")),
+            Subsignal("int_n",   PinsN("L16", dir="o")),
             Subsignal("mdio",    Pins("N17", dir="io")),
             Subsignal("mdc",     Pins("F16", dir="o")), # Max 8.3MHz
             Subsignal("tx_clk",  Pins("K16", dir="i")),
@@ -142,8 +142,8 @@ class AtlysPlatform(XilinxSpartan6Platform):
         ),
         # Device does not support RMII
         Resource("eth_tbi", 0,
-            Subsignal("rst",     PinsN("G13", dir="o")),
-            Subsignal("int",     PinsN("L16", dir="o")),
+            Subsignal("rst_n",   PinsN("G13", dir="o")),
+            Subsignal("int_n",   PinsN("L16", dir="o")),
             Subsignal("mdio",    Pins("N17", dir="io")),
             Subsignal("mdc",     Pins("F16", dir="o")), # Max 8.3MHz
             Subsignal("tx_clk",  Pins("L12", dir="o")),
@@ -155,8 +155,8 @@ class AtlysPlatform(XilinxSpartan6Platform):
             Attrs(IOSTANDARD="LVCMOS33")
         ),
         Resource("eth_rtbi", 0,
-            Subsignal("rst",     PinsN("G13", dir="o")),
-            Subsignal("int",     PinsN("L16", dir="o")),
+            Subsignal("rst_n",   PinsN("G13", dir="o")),
+            Subsignal("int_n",   PinsN("L16", dir="o")),
             Subsignal("mdio",    Pins("N17", dir="io")),
             Subsignal("mdc",     Pins("F16", dir="o")), # Max 8.3MHz
             Subsignal("tx_clk",  Pins("L12", dir="o")),

--- a/nmigen_boards/ecp5_5g_evn.py
+++ b/nmigen_boards/ecp5_5g_evn.py
@@ -71,7 +71,7 @@ class ECP55GEVNPlatform(LatticeECP5Platform):
 
         *SPIFlashResources(0,
             cs="R2", clk="U3", cipo="V2", copi="W2", wp="Y2", hold="W1",
-            attrs=Attrs(IO_STANDARD="LVCMOS33")
+            attrs=Attrs(IO_TYPE="LVCMOS33")
         ),
 
         Resource("serdes", 0,

--- a/nmigen_boards/ecp5_5g_evn.py
+++ b/nmigen_boards/ecp5_5g_evn.py
@@ -14,7 +14,7 @@ class ECP55GEVNPlatform(LatticeECP5Platform):
     package     = "BG381"
     speed       = "8"
     default_clk = "clk12"
-    default_rst = "rst"
+    default_rst = "rst_n"
 
     def __init__(self, *, VCCIO1="2V5", VCCIO6="3V3", **kwargs):
         """
@@ -43,7 +43,7 @@ class ECP55GEVNPlatform(LatticeECP5Platform):
         return self._vccio_to_iostandard(self._VCCIO6)
 
     resources   = [
-        Resource("rst", 0, PinsN("G2", dir="i"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("rst_n", 0, PinsN("G2", dir="i"), Attrs(IO_TYPE="LVCMOS33")),
         Resource("clk12", 0, Pins("A10", dir="i"),
                  Clock(12e6), Attrs(IO_TYPE="LVCMOS33")),
 

--- a/nmigen_boards/ecpix5.py
+++ b/nmigen_boards/ecpix5.py
@@ -13,10 +13,10 @@ class _ECPIX5Platform(LatticeECP5Platform):
     package     = "BG554"
     speed       = "8"
     default_clk = "clk100"
-    default_rst = "rst"
+    default_rst = "rst_n"
 
     resources   = [
-        Resource("rst", 0, PinsN("AB1", dir="i"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("rst_n", 0, PinsN("AB1", dir="i"), Attrs(IO_TYPE="LVCMOS33")),
         Resource("clk100", 0, Pins("K23", dir="i"), Clock(100e6), Attrs(IO_TYPE="LVCMOS33")),
 
         RGBLEDResource(0,
@@ -47,7 +47,7 @@ class _ECPIX5Platform(LatticeECP5Platform):
         ),
 
         Resource("eth_rgmii", 0,
-            Subsignal("rst",     PinsN("C13", dir="o")),
+            Subsignal("rst_n",   PinsN("C13", dir="o")),
             Subsignal("mdio",    Pins("A13", dir="io")),
             Subsignal("mdc",     Pins("C11", dir="o")),
             Subsignal("tx_clk",  Pins("A12", dir="o")),
@@ -58,14 +58,14 @@ class _ECPIX5Platform(LatticeECP5Platform):
             Subsignal("rx_data", Pins("B11 A10 B10 A9", dir="i")),
             Attrs(IO_TYPE="LVCMOS33")
         ),
-        Resource("eth_int", 0, PinsN("B13", dir="i"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("eth_int_n", 0, PinsN("B13", dir="i"), Attrs(IO_TYPE="LVCMOS33")),
 
         Resource("ddr3", 0,
             Subsignal("clk",    DiffPairs("H3", "J3", dir="o"), Attrs(IO_TYPE="SSTL135D_I")),
             Subsignal("clk_en", Pins("P1", dir="o")),
-            Subsignal("we",     PinsN("R3", dir="o")),
-            Subsignal("ras",    PinsN("T3", dir="o")),
-            Subsignal("cas",    PinsN("P2", dir="o")),
+            Subsignal("we_n",   PinsN("R3", dir="o")),
+            Subsignal("ras_n",  PinsN("T3", dir="o")),
+            Subsignal("cas_n",  PinsN("P2", dir="o")),
             Subsignal("a",      Pins("T5 M3 L3 V6 K2 W6 K3 L1 H2 L2 N1 J1 M1 K1", dir="o")),
             Subsignal("ba",     Pins("U6 N3 N4", dir="o")),
             Subsignal("dqs",    DiffPairs("V4 V1", "U5 U2", dir="io"),
@@ -94,11 +94,11 @@ class _ECPIX5Platform(LatticeECP5Platform):
         ),
 
         Resource("usbc_cfg", 0,
-            Subsignal("scl", Pins("D24", dir="io")),
-            Subsignal("sda", Pins("C24", dir="io")),
-            Subsignal("dir", Pins("B23", dir="i")),
-            Subsignal("id",  Pins("D23", dir="i")),
-            Subsignal("int", PinsN("B24", dir="i")),
+            Subsignal("scl",   Pins("D24", dir="io")),
+            Subsignal("sda",   Pins("C24", dir="io")),
+            Subsignal("dir",   Pins("B23", dir="i")),
+            Subsignal("id",    Pins("D23", dir="i")),
+            Subsignal("int_n", PinsN("B24", dir="i")),
             Attrs(IO_TYPE="LVCMOS33")
         ),
         Resource("usbc_mux", 0,
@@ -162,7 +162,7 @@ class ECPIX545Platform(_ECPIX5Platform):
 
         # The IT6613E HDMI transmitter has access to 8 bits per color channel.
         Resource("it6613e", 0,
-            Subsignal("rst",   PinsN("N6", dir="o")),
+            Subsignal("rst_n", PinsN("N6", dir="o")),
             Subsignal("scl",   Pins("C17", dir="io")),
             Subsignal("sda",   Pins("E17", dir="io")),
             Subsignal("pclk",  Pins("C1", dir="o")),
@@ -178,7 +178,7 @@ class ECPIX545Platform(_ECPIX5Platform):
             Subsignal("sck",   Pins("D6", dir="o")),
             Subsignal("ws",    Pins("C6", dir="o")),
             Subsignal("i2s",   Pins("A6 B6 A5 C5", dir="o")),
-            Subsignal("int",   PinsN("C4", dir="i")),
+            Subsignal("int_n", PinsN("C4", dir="i")),
             Attrs(IO_TYPE="LVTTL33")
         ),
     ]
@@ -193,7 +193,7 @@ class ECPIX585Platform(_ECPIX5Platform):
         # The IT6613E HDMI transmitter has access to 12 bits per color channel. The LFE5UM5G-85F
         # has an additional I/O bank which is used to provide the lower 4 bits of each channel.
         Resource("it6613e", 0,
-            Subsignal("rst",   PinsN("N6", dir="o")),
+            Subsignal("rst_n", PinsN("N6", dir="o")),
             Subsignal("scl",   Pins("C17", dir="io")),
             Subsignal("sda",   Pins("E17", dir="io")),
             Subsignal("pclk",  Pins("C1", dir="o")),
@@ -209,7 +209,7 @@ class ECPIX585Platform(_ECPIX5Platform):
             Subsignal("sck",   Pins("D6", dir="o")),
             Subsignal("ws",    Pins("C6", dir="o")),
             Subsignal("i2s",   Pins("A6 B6 A5 C5", dir="o")),
-            Subsignal("int",   PinsN("C4", dir="i")),
+            Subsignal("int_n", PinsN("C4", dir="i")),
             Attrs(IO_TYPE="LVTTL33")
         ),
     ]

--- a/nmigen_boards/genesys2.py
+++ b/nmigen_boards/genesys2.py
@@ -26,10 +26,10 @@ class Genesys2Platform(Xilinx7SeriesPlatform):
     def bank15_16_17_iostandard(self):
         return "LVCMOS" + self._JP6.replace('V', '')
 
-    default_rst = "rst"
+    default_rst = "rst_n"
     default_clk = "clk"
     resources = [
-        Resource("rst", 0, PinsN("R19", dir="i"),
+        Resource("rst_n", 0, PinsN("R19", dir="i"),
                  Attrs(IOSTANDARD="LVCMOS33")),
         Resource("clk", 0, DiffPairs(p="AD12 ", n="AD11", dir="i"),
                  Clock(200e6), Attrs(IOSTANDARD="LVDS")),
@@ -55,16 +55,16 @@ class Genesys2Platform(Xilinx7SeriesPlatform):
         I2CResource(0, scl="AE30", sda="AF30",
                     attrs=Attrs(IOSTANDARD="LVCMOS33")),
         Resource("ddr3", 0,
-                 Subsignal("rst", PinsN("AG5", dir="o"),
+                 Subsignal("rst_n", PinsN("AG5", dir="o"),
                            Attrs(IOSTANDARD="SSTL15")),
                  Subsignal("clk",
                            DiffPairs(p="AB9", n="AC9", dir="o"),
                            Attrs(IOSTANDARD="DIFF_SSTL15_DCI")),
                  Subsignal("clk_en", Pins("AJ9", dir="o")),
-                 Subsignal("cs", PinsN("AH12", dir="o")),
-                 Subsignal("we", PinsN("AG13", dir="o")),
-                 Subsignal("ras", PinsN("AE11", dir="o")),
-                 Subsignal("cas", PinsN("AF11", dir="o")),
+                 Subsignal("cs_n", PinsN("AH12", dir="o")),
+                 Subsignal("we_n", PinsN("AG13", dir="o")),
+                 Subsignal("ras_n", PinsN("AE11", dir="o")),
+                 Subsignal("cas_n", PinsN("AF11", dir="o")),
                  Subsignal("a", Pins(
                      "AC12 AE8 AD8 AC10 AD9 AA13 AA10 AA11 "
                      "Y10 Y11 AB8 AA8 AB12 AA12 AH9 AG9", dir="o")),
@@ -102,8 +102,8 @@ class Genesys2Platform(Xilinx7SeriesPlatform):
                     attrs=Attrs(IOSTANDARD="LVCMOS18")),
         Resource("oled", 0,  # OLED, UG-2832HSWEG04
                  Subsignal("dc", Pins("AC17", dir="o")),
-                 Subsignal("vdd_en", PinsN("AG17", dir="o")),
-                 Subsignal("vbat_en", PinsN("AB22", dir="o"),
+                 Subsignal("vdd_en_n", PinsN("AG17", dir="o")),
+                 Subsignal("vbat_en_n", PinsN("AB22", dir="o"),
                            Attrs(IOSTANDARD="LVCMOS33")),
                  Attrs(IOSTANDARD="LVCMOS18")),
         Resource("hdmi", 0,  # HDMI TX, connector J4
@@ -132,8 +132,8 @@ class Genesys2Platform(Xilinx7SeriesPlatform):
                  Subsignal("g", Pins("AJ23 AJ22 AH22 AK21 AJ21 AK23",
                                      dir="o")),
                  Subsignal("b", Pins("AH20 AG20 AF21 AK20 AG22", dir="o")),
-                 Subsignal("hsync", PinsN("AF20", dir="o")),
-                 Subsignal("vsync", PinsN("AG23", dir="o")),
+                 Subsignal("hsync_n", PinsN("AF20", dir="o")),
+                 Subsignal("vsync_n", PinsN("AG23", dir="o")),
                  Attrs(IOSTANDARD="LVCMOS33")),
         *SDCardResources(0, clk="R28", cmd="R29", dat0="R26", dat1="R30",
                          dat2="P29", dat3="T30", cd="P28",
@@ -143,10 +143,10 @@ class Genesys2Platform(Xilinx7SeriesPlatform):
         ULPIResource(0, data="AE14 AE15 AC15 AC16 AB15 AA15 AD14 AC14",
                      rst="AB14", clk="AD18", dir="Y16", stp="AA17", nxt="AA16",
                      clk_dir="i", rst_invert=True, attrs=Attrs(IOSTANDARD="LVCMOS18")),
-        Resource("vusb_oc", 0,
+        Resource("vusb_oc_n", 0,
                  PinsN("AF16", dir="i"), Attrs(IOSTANDARD="LVCMOS18")),
         Resource("eth_rgmii", 0,
-                 Subsignal("rst", PinsN("AH24", dir="o"),
+                 Subsignal("rst_n", PinsN("AH24", dir="o"),
                            Attrs(IOSTANDARD="LVCMOS33")),
                  Subsignal("mdc", Pins("AF12", dir="o")),
                  Subsignal("mdio", Pins("AG12", dir="io")),

--- a/nmigen_boards/ice40_up5k_b_evn.py
+++ b/nmigen_boards/ice40_up5k_b_evn.py
@@ -23,11 +23,11 @@ class ICE40UP5KBEVNPlatform(LatticeICE40Platform):
             pins="39 40 41", invert=True,
             attrs=Attrs(IO_STANDARD="SB_LVCMOS")
         ),
-        Resource("led_b", 0, PinsN("39", dir="o"),
+        Resource("led_b_n", 0, PinsN("39", dir="o"),
                  Attrs(IO_STANDARD="SB_LVCMOS")),
-        Resource("led_g", 0, PinsN("40", dir="o"),
+        Resource("led_g_n", 0, PinsN("40", dir="o"),
                  Attrs(IO_STANDARD="SB_LVCMOS")),
-        Resource("led_r", 0, PinsN("41", dir="o"),
+        Resource("led_r_n", 0, PinsN("41", dir="o"),
                  Attrs(IO_STANDARD="SB_LVCMOS")),
 
         # 4 DIP switches are available, requiring internal pull-ups.

--- a/nmigen_boards/icebreaker.py
+++ b/nmigen_boards/icebreaker.py
@@ -19,8 +19,8 @@ class ICEBreakerPlatform(LatticeICE40Platform):
 
         *LEDResources(pins="11 37", invert=True, attrs=Attrs(IO_STANDARD="SB_LVCMOS")),
         # Semantic aliases
-        Resource("led_r", 0, PinsN("11", dir="o"), Attrs(IO_STANDARD="SB_LVCMOS")),
-        Resource("led_g", 0, PinsN("37", dir="o"), Attrs(IO_STANDARD="SB_LVCMOS")),
+        Resource("led_r_n", 0, PinsN("11", dir="o"), Attrs(IO_STANDARD="SB_LVCMOS")),
+        Resource("led_g_n", 0, PinsN("37", dir="o"), Attrs(IO_STANDARD="SB_LVCMOS")),
 
         *ButtonResources(pins="10", invert=True, attrs=Attrs(IO_STANDARD="SB_LVCMOS")),
 

--- a/nmigen_boards/icebreaker_bitsy.py
+++ b/nmigen_boards/icebreaker_bitsy.py
@@ -28,8 +28,8 @@ class ICEBreakerBitsyPlatform(LatticeICE40Platform):
         RGBLEDResource(0, r="39", g="40", b="41", invert=True,
             attrs=Attrs(IO_STANDARD="SB_LVCMOS")),
         *LEDResources(pins="25 6", invert=True, attrs=Attrs(IO_STANDARD="SB_LVCMOS")),
-        Resource("led_r", 0, PinsN("25", dir="o"), Attrs(IO_STANDARD="SB_LVCMOS")),
-        Resource("led_g", 0, PinsN("6", dir="o"), Attrs(IO_STANDARD="SB_LVCMOS")),
+        Resource("led_r_n", 0, PinsN("25", dir="o"), Attrs(IO_STANDARD="SB_LVCMOS")),
+        Resource("led_g_n", 0, PinsN("6", dir="o"), Attrs(IO_STANDARD="SB_LVCMOS")),
 
         *ButtonResources(pins="2", invert=True, attrs=Attrs(IO_STANDARD="SB_LVCMOS")),
     ]

--- a/nmigen_boards/mercury.py
+++ b/nmigen_boards/mercury.py
@@ -62,7 +62,7 @@ class MercuryPlatform(XilinxSpartan3APlatform):
         # under SRAMResource) interface to the SRAM. On assertion, this signal
         # will tristate the level-shifters, preventing any output on the 5V
         # GPIO pins (including gpio:30 and gpio:20).
-        Resource("bussw_oe", 0, PinsN("P30N", dir="o"),
+        Resource("bussw_oe_n", 0, PinsN("P30N", dir="o"),
             Attrs(IOSTANDARD="LVTTL"))
     ]
 
@@ -160,8 +160,8 @@ class MercuryPlatform(XilinxSpartan3APlatform):
 
     _vga = [
         Resource("vga_out", 0,
-            Subsignal("hsync", PinsN("led_0:3", dir="o")),
-            Subsignal("vsync", PinsN("led_0:4", dir="o")),
+            Subsignal("hsync_n", PinsN("led_0:3", dir="o")),
+            Subsignal("vsync_n", PinsN("led_0:4", dir="o")),
 
             Subsignal("r", Pins("dio_0:1 dio_0:2 dio_0:3", dir="o")),
             Subsignal("g", Pins("dio_0:4 dio_0:5 dio_0:6", dir="o")),

--- a/nmigen_boards/mister.py
+++ b/nmigen_boards/mister.py
@@ -72,13 +72,13 @@ class MisterPlatform(IntelPlatform):
 
         # MiSTer I/O Board (optional, but highly recommended)
         # https://github.com/MiSTer-devel/Hardware_MiSTer/blob/master/releases/iobrd_6.0.pdf
-        Resource("power_led", 0, PinsN("1", dir="o", conn=("gpio", 1)), Attrs(io_standard="3.3-V LVTTL")),
-        Resource("disk_led", 0, PinsN("3", dir="o", conn=("gpio", 1)), Attrs(io_standard="3.3-V LVTTL")),
-        Resource("user_led", 0, PinsN("5", dir="o", conn=("gpio", 1)), Attrs(io_standard="3.3-V LVTTL")),
+        Resource("power_led_n", 0, PinsN("1", dir="o", conn=("gpio", 1)), Attrs(io_standard="3.3-V LVTTL")),
+        Resource("disk_led_n", 0, PinsN("3", dir="o", conn=("gpio", 1)), Attrs(io_standard="3.3-V LVTTL")),
+        Resource("user_led_n", 0, PinsN("5", dir="o", conn=("gpio", 1)), Attrs(io_standard="3.3-V LVTTL")),
 
-        Resource("reset_switch", 0, PinsN("17", dir="i", conn=("gpio", 1)), Attrs(io_standard="3.3-V LVTTL")),
-        Resource("osd_switch", 0, PinsN("13", dir="i", conn=("gpio", 1)), Attrs(io_standard="3.3-V LVTTL")),
-        Resource("user_switch", 0, PinsN("15", dir="i", conn=("gpio", 1)), Attrs(io_standard="3.3-V LVTTL")),
+        Resource("reset_switch_n", 0, PinsN("17", dir="i", conn=("gpio", 1)), Attrs(io_standard="3.3-V LVTTL")),
+        Resource("osd_switch_n", 0, PinsN("13", dir="i", conn=("gpio", 1)), Attrs(io_standard="3.3-V LVTTL")),
+        Resource("user_switch_n", 0, PinsN("15", dir="i", conn=("gpio", 1)), Attrs(io_standard="3.3-V LVTTL")),
 
         Resource("audio", 0,
             Subsignal("l", Pins("2", dir="o", conn=("gpio", 1))),

--- a/nmigen_boards/nexys4ddr.py
+++ b/nmigen_boards/nexys4ddr.py
@@ -14,11 +14,11 @@ class Nexys4DDRPlatform(Xilinx7SeriesPlatform):
     package     = "csg324"
     speed       = "1"
     default_clk = "clk100"
-    default_rst = "rst"
+    default_rst = "rst_n"
     resources   = [
         Resource("clk100", 0,
             Pins("E3", dir="i"), Clock(100e6), Attrs(IOSTANDARD="LVCMOS33")),
-        Resource("rst", 0,
+        Resource("rst_n", 0,
             PinsN("C12", dir="i"), Attrs(IOSTANDARD="LVCMOS33")),
 
         *SwitchResources(
@@ -40,11 +40,11 @@ class Nexys4DDRPlatform(Xilinx7SeriesPlatform):
             a="T10", b="R10", c="K16", d="K13", e="P15",
             f="T11", g="L18", dp="H15", invert=True,
             attrs=Attrs(IOSTANDARD="LVCMOS33")),
-        Resource("display_7seg_an", 0,
+        Resource("display_7seg_an_n", 0,
             PinsN("J17 J18 T9 J14 P14 T14 K2 U13", dir="o"),
             Attrs(IOSTANDARD="LVCMOS33")),
 
-        Resource("button_reset", 0,
+        Resource("button_reset_n", 0,
             PinsN("C12", dir="i"), Attrs(IOSTANDARD="LVCMOS33")),
         Resource("button_center", 0,
             Pins("N17",  dir="i"), Attrs(IOSTANDARD="LVCMOS33")),
@@ -73,7 +73,7 @@ class Nexys4DDRPlatform(Xilinx7SeriesPlatform):
             Pins("E2", dir="o"), Attrs(IOSTANDARD="LVCMOS33")),
 
         Resource("accelerometer", 0,                        # ADXL362
-            Subsignal("cs",   PinsN("D15",    dir="o")),
+            Subsignal("cs_n", PinsN("D15",    dir="o")),
             Subsignal("clk",  Pins("F15",     dir="o")),
             Subsignal("copi", Pins("F14",     dir="o")),
             Subsignal("cipo", Pins("E15",     dir="i")),
@@ -95,8 +95,8 @@ class Nexys4DDRPlatform(Xilinx7SeriesPlatform):
             Attrs(IOSTANDARD="LVCMOS33")),
 
         Resource("audio", 0,
-            Subsignal("pwm", Pins("A11",  dir="o")),
-            Subsignal("sd",  PinsN("D12", dir="o")),
+            Subsignal("pwm",  Pins("A11",  dir="o")),
+            Subsignal("sd_n", PinsN("D12", dir="o")),
             Attrs(IOSTANDARD="LVCMOS33")),
 
         UARTResource(0,
@@ -118,7 +118,7 @@ class Nexys4DDRPlatform(Xilinx7SeriesPlatform):
             Subsignal("txd",    Pins("A10 A8",  dir="o")),
             Subsignal("txen",   Pins("B9",      dir="o")),
             Subsignal("crs_dv", Pins("D9",      dir="io")),
-            Subsignal("int",    PinsN("B8",     dir="io")),
+            Subsignal("int_n",  PinsN("B8",     dir="io")),
             Subsignal("clk",    Pins("D5",      dir="o"), Clock(50e6)),
             Attrs(IOSTANDARD="LVCMOS33")),
 
@@ -136,11 +136,11 @@ class Nexys4DDRPlatform(Xilinx7SeriesPlatform):
             Subsignal("clk", DiffPairs("L6", "L5", dir="o"),
                 Attrs(IOSTANDARD="DIFF_SSTL18_I")),
             Subsignal("clk_en", Pins("M1", dir="o")),
-            Subsignal("cs",  PinsN("K6", dir="o")),
-            Subsignal("we",  PinsN("N2", dir="o")),
-            Subsignal("ras", PinsN("N4", dir="o")),
-            Subsignal("cas", PinsN("L1", dir="o")),
-            Subsignal("dqs", DiffPairs("U9 U2", "V9 V2", dir="o"),
+            Subsignal("cs_n",   PinsN("K6", dir="o")),
+            Subsignal("we_n",   PinsN("N2", dir="o")),
+            Subsignal("ras_n",  PinsN("N4", dir="o")),
+            Subsignal("cas_n",  PinsN("L1", dir="o")),
+            Subsignal("dqs",    DiffPairs("U9 U2", "V9 V2", dir="o"),
                 Attrs(IOSTANDARD="DIFF_SSTL18_I")),
             Subsignal("dm",  Pins("T6 U1", dir="o")),
             Subsignal("odt", Pins("R5",    dir="o")),

--- a/nmigen_boards/orangecrab_r0_1.py
+++ b/nmigen_boards/orangecrab_r0_1.py
@@ -21,7 +21,7 @@ class OrangeCrabR0_1Platform(LatticeECP5Platform):
 
         # Used to reload FPGA configuration.
         # Can enter USB bootloader by assigning button 0 to program.
-        Resource("program", 0, PinsN("V17", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("program_n", 0, PinsN("V17", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
 
         RGBLEDResource(0,
             r="V17", g="T17", b="J3", invert=True,
@@ -33,13 +33,13 @@ class OrangeCrabR0_1Platform(LatticeECP5Platform):
         ),
 
         Resource("ddr3", 0,
-            Subsignal("rst",     PinsN("B1", dir="o")),
+            Subsignal("rst_n",   PinsN("B1", dir="o")),
             Subsignal("clk",     DiffPairs("J18", "K18", dir="o"), Attrs(IO_TYPE="SSTL135D_I")),
             Subsignal("clk_en",  Pins("D6", dir="o")),
-            Subsignal("cs",      PinsN("A12", dir="o")),
-            Subsignal("we",      PinsN("B12", dir="o")),
-            Subsignal("ras",     PinsN("C12", dir="o")),
-            Subsignal("cas",     PinsN("D13", dir="o")),
+            Subsignal("cs_n",    PinsN("A12", dir="o")),
+            Subsignal("we_n",    PinsN("B12", dir="o")),
+            Subsignal("ras_n",   PinsN("C12", dir="o")),
+            Subsignal("cas_n",   PinsN("D13", dir="o")),
             Subsignal("a",       Pins("A4 D2 C3 C7 D3 D4 D1 B2 C1 A2 A7 C2 C4", dir="o")),
             Subsignal("ba",      Pins("B6 B7 A6", dir="o")),
             Subsignal("dqs",     DiffPairs("G18 H17", "B15 A16", dir="io"),
@@ -54,8 +54,8 @@ class OrangeCrabR0_1Platform(LatticeECP5Platform):
 
         Resource("ddr3_pseudo_power", 0,
             # pseudo power pins, leave these at their default value
-            Subsignal("vcc_virtual", PinsN("A3 B18 C6 C15 D17 D18 K15 K16 K17", dir="o")),
-            Subsignal("gnd_virtual", Pins("L15 L16 L18", dir="o")),
+            Subsignal("vcc_virtual_n", PinsN("A3 B18 C6 C15 D17 D18 K15 K16 K17", dir="o")),
+            Subsignal("gnd_virtual",   Pins("L15 L16 L18", dir="o")),
             Attrs(IO_TYPE="SSTL135_II", SLEWRATE="FAST")
         ),
 

--- a/nmigen_boards/orangecrab_r0_2.py
+++ b/nmigen_boards/orangecrab_r0_2.py
@@ -21,7 +21,7 @@ class OrangeCrabR0_2Platform(LatticeECP5Platform):
 
         # Used to reload FPGA configuration.
         # Can enter USB bootloader by assigning button 0 to program.
-        Resource("program", 0, PinsN("V17", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("program_n", 0, PinsN("V17", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
 
         RGBLEDResource(0, 
             r="K4", g="M3", b="J3", invert=True,
@@ -37,13 +37,13 @@ class OrangeCrabR0_2Platform(LatticeECP5Platform):
         ),
 
         Resource("ddr3", 0,
-            Subsignal("rst",     PinsN("L18", dir="o")),
+            Subsignal("rst_n",   PinsN("L18", dir="o")),
             Subsignal("clk",     DiffPairs("J18", "K18", dir="o"), Attrs(IO_TYPE="SSTL135D_I")),
             Subsignal("clk_en",  Pins("D18", dir="o")),
-            Subsignal("cs",      PinsN("A12", dir="o")),
-            Subsignal("we",      PinsN("B12", dir="o")),
-            Subsignal("ras",     PinsN("C12", dir="o")),
-            Subsignal("cas",     PinsN("D13", dir="o")),
+            Subsignal("cs_n",    PinsN("A12", dir="o")),
+            Subsignal("we_n",    PinsN("B12", dir="o")),
+            Subsignal("ras_n",   PinsN("C12", dir="o")),
+            Subsignal("cas_n",   PinsN("D13", dir="o")),
             Subsignal("a",       Pins("C4 D2 D3 A3 A4 D4 C3 B2 B1 D1 A7 C2 B6 C1 A2 C7", dir="o")),
             Subsignal("ba",      Pins("P5 N3 M3", dir="o")),
             Subsignal("dqs",     DiffPairs("G18 H17", "B15 A16", dir="io"),
@@ -58,8 +58,8 @@ class OrangeCrabR0_2Platform(LatticeECP5Platform):
 
         Resource("ddr3_pseudo_power", 0,
             # pseudo power pins, leave these at their default value
-            Subsignal("vcc_virtual", PinsN("K16 D17 K15 K17 B18 C6", dir="o")),
-            Subsignal("gnd_virtual", Pins("L15 L16", dir="o")),
+            Subsignal("vcc_virtual_n", PinsN("K16 D17 K15 K17 B18 C6", dir="o")),
+            Subsignal("gnd_virtual",   Pins("L15 L16", dir="o")),
             Attrs(IO_TYPE="SSTL135_II", SLEWRATE="FAST")
         ),
 

--- a/nmigen_boards/resources/interface.py
+++ b/nmigen_boards/resources/interface.py
@@ -38,39 +38,39 @@ def UARTResource(*args, rx, tx, rts=None, cts=None, dtr=None, dsr=None, dcd=None
     return Resource.family(*args, default_name="uart", ios=io)
 
 
-def IrDAResource(number, *, rx, tx, en=None, sd=None,
+def IrDAResource(number, *, rx, tx, en=None, sd_n=None,
                  conn=None, attrs=None):
-    # Exactly one of en (active-high enable) or sd (shutdown, active-low enable) should
+    # Exactly one of en (active-high enable) or sd_n (shutdown, active-low enable) should
     # be specified, and it is mapped to a logic level en subsignal.
-    assert (en is not None) ^ (sd is not None)
+    assert (en is not None) ^ (sd_n is not None)
 
     io = []
     io.append(Subsignal("rx", Pins(rx, dir="i", conn=conn, assert_width=1)))
     io.append(Subsignal("tx", Pins(tx, dir="o", conn=conn, assert_width=1)))
     if en is not None:
         io.append(Subsignal("en", Pins(en, dir="o", conn=conn, assert_width=1)))
-    if sd is not None:
-        io.append(Subsignal("en", PinsN(sd, dir="o", conn=conn, assert_width=1)))
+    if sd_n is not None:
+        io.append(Subsignal("en_n", PinsN(sd_n, dir="o", conn=conn, assert_width=1)))
     if attrs is not None:
         io.append(attrs)
     return Resource("irda", number, *io)
 
 
-def SPIResource(*args, cs, clk, copi, cipo, int=None, reset=None,
+def SPIResource(*args, cs_n, clk, copi, cipo, int=None, reset=None,
                 conn=None, attrs=None, role="controller"):
     assert role in ("controller", "peripheral")
     assert copi is not None or cipo is not None # support unidirectional SPI
 
     io = []
     if role == "controller":
-        io.append(Subsignal("cs", PinsN(cs, dir="o", conn=conn)))
+        io.append(Subsignal("cs_n", PinsN(cs_n, dir="o", conn=conn)))
         io.append(Subsignal("clk", Pins(clk, dir="o", conn=conn, assert_width=1)))
         if copi is not None:
             io.append(Subsignal("copi", Pins(copi, dir="o", conn=conn, assert_width=1)))
         if cipo is not None:
             io.append(Subsignal("cipo", Pins(cipo, dir="i", conn=conn, assert_width=1)))
     else:  # peripheral
-        io.append(Subsignal("cs", PinsN(cs, dir="i", conn=conn, assert_width=1)))
+        io.append(Subsignal("cs_n", PinsN(cs_n, dir="i", conn=conn, assert_width=1)))
         io.append(Subsignal("clk", Pins(clk, dir="i", conn=conn, assert_width=1)))
         if copi is not None:
             io.append(Subsignal("copi", Pins(copi, dir="i", conn=conn, assert_width=1)))

--- a/nmigen_boards/resources/memory.py
+++ b/nmigen_boards/resources/memory.py
@@ -7,22 +7,22 @@ __all__ = [
 ]
 
 
-def SPIFlashResources(*args, cs, clk, copi, cipo, wp=None, hold=None,
+def SPIFlashResources(*args, cs_n, clk, copi, cipo, wp_n=None, hold=None,
                       conn=None, attrs=None):
     resources = []
 
     io_all = []
     if attrs is not None:
         io_all.append(attrs)
-    io_all.append(Subsignal("cs",  PinsN(cs, dir="o", conn=conn)))
-    io_all.append(Subsignal("clk", Pins(clk, dir="o", conn=conn, assert_width=1)))
+    io_all.append(Subsignal("cs_n", PinsN(cs_n, dir="o", conn=conn)))
+    io_all.append(Subsignal("clk",  Pins(clk, dir="o", conn=conn, assert_width=1)))
 
     io_1x = list(io_all)
     io_1x.append(Subsignal("copi", Pins(copi, dir="o", conn=conn, assert_width=1)))
     io_1x.append(Subsignal("cipo", Pins(cipo, dir="i", conn=conn, assert_width=1)))
-    if wp is not None and hold is not None:
-        io_1x.append(Subsignal("wp",   PinsN(wp,   dir="o", conn=conn, assert_width=1)))
-        io_1x.append(Subsignal("hold", PinsN(hold, dir="o", conn=conn, assert_width=1)))
+    if wp_n is not None and hold is not None:
+        io_1x.append(Subsignal("wp_n",   PinsN(wp_n, dir="o", conn=conn, assert_width=1)))
+        io_1x.append(Subsignal("hold_n", PinsN(hold, dir="o", conn=conn, assert_width=1)))
     resources.append(Resource.family(*args, default_name="spi_flash", ios=io_1x,
                                      name_suffix="1x"))
 
@@ -32,9 +32,9 @@ def SPIFlashResources(*args, cs, clk, copi, cipo, wp=None, hold=None,
     resources.append(Resource.family(*args, default_name="spi_flash", ios=io_2x,
                                      name_suffix="2x"))
 
-    if wp is not None and hold is not None:
+    if wp_n is not None and hold is not None:
         io_4x = list(io_all)
-        io_4x.append(Subsignal("dq", Pins(" ".join([copi, cipo, wp, hold]), dir="io", conn=conn,
+        io_4x.append(Subsignal("dq", Pins(" ".join([copi, cipo, wp_n, hold]), dir="io", conn=conn,
                                           assert_width=4)))
         resources.append(Resource.family(*args, default_name="spi_flash", ios=io_4x,
                                          name_suffix="4x"))
@@ -42,7 +42,7 @@ def SPIFlashResources(*args, cs, clk, copi, cipo, wp=None, hold=None,
     return resources
 
 
-def SDCardResources(*args, clk, cmd, dat0, dat1=None, dat2=None, dat3=None, cd=None, wp=None,
+def SDCardResources(*args, clk, cmd, dat0, dat1=None, dat2=None, dat3=None, cd=None, wp_n=None,
                     conn=None, attrs=None):
     resources = []
 
@@ -51,8 +51,8 @@ def SDCardResources(*args, clk, cmd, dat0, dat1=None, dat2=None, dat3=None, cd=N
         io_common.append(attrs)
     if cd is not None:
         io_common.append(Subsignal("cd", Pins(cd, dir="i", conn=conn, assert_width=1)))
-    if wp is not None:
-        io_common.append(Subsignal("wp", PinsN(wp, dir="i", conn=conn, assert_width=1)))
+    if wp_n is not None:
+        io_common.append(Subsignal("wp_n", PinsN(wp_n, dir="i", conn=conn, assert_width=1)))
 
     io_native = list(io_common)
     io_native.append(Subsignal("clk", Pins(clk, dir="o", conn=conn, assert_width=1)))
@@ -76,7 +76,7 @@ def SDCardResources(*args, clk, cmd, dat0, dat1=None, dat2=None, dat3=None, cd=N
     if dat3 is not None:
         io_spi = list(io_common)
         # DAT3/CS# has a pullup and doubles as electronic card detect
-        io_spi.append(Subsignal("cs", PinsN(dat3, dir="io", conn=conn, assert_width=1)))
+        io_spi.append(Subsignal("cs_n", PinsN(dat3, dir="io", conn=conn, assert_width=1)))
         io_spi.append(Subsignal("clk", Pins(clk, dir="o", conn=conn, assert_width=1)))
         io_spi.append(Subsignal("copi", Pins(cmd, dir="o", conn=conn, assert_width=1)))
         io_spi.append(Subsignal("cipo", Pins(dat0, dir="i", conn=conn, assert_width=1)))
@@ -86,34 +86,34 @@ def SDCardResources(*args, clk, cmd, dat0, dat1=None, dat2=None, dat3=None, cd=N
     return resources
 
 
-def SRAMResource(*args, cs, oe=None, we, a, d, dm=None,
+def SRAMResource(*args, cs_n, oe_n=None, we_n, a, d, dm_n=None,
                  conn=None, attrs=None):
     io = []
-    io.append(Subsignal("cs", PinsN(cs, dir="o", conn=conn, assert_width=1)))
-    if oe is not None:
+    io.append(Subsignal("cs_n", PinsN(cs_n, dir="o", conn=conn, assert_width=1)))
+    if oe_n is not None:
         # Asserted WE# deactivates the D output buffers, so WE# can be used to replace OE#.
-        io.append(Subsignal("oe", PinsN(oe, dir="o", conn=conn, assert_width=1)))
-    io.append(Subsignal("we", PinsN(we, dir="o", conn=conn, assert_width=1)))
+        io.append(Subsignal("oe", PinsN(oe_n, dir="o", conn=conn, assert_width=1)))
+    io.append(Subsignal("we_n", PinsN(we_n, dir="o", conn=conn, assert_width=1)))
     io.append(Subsignal("a", Pins(a, dir="o", conn=conn)))
     io.append(Subsignal("d", Pins(d, dir="io", conn=conn)))
-    if dm is not None:
-        io.append(Subsignal("dm", PinsN(dm, dir="o", conn=conn))) # dm="LB# UB#"
+    if dm_n is not None:
+        io.append(Subsignal("dm_n", PinsN(dm_n, dir="o", conn=conn))) # dm="LB# UB#"
     if attrs is not None:
         io.append(attrs)
     return Resource.family(*args, default_name="sram", ios=io)
 
 
-def SDRAMResource(*args, clk, cke=None, cs=None, we, ras, cas, ba, a, dq, dqm=None,
+def SDRAMResource(*args, clk, cke=None, cs_n=None, we_n, ras_n, cas_n, ba, a, dq, dqm=None,
                   conn=None, attrs=None):
     io = []
     io.append(Subsignal("clk", Pins(clk, dir="o", conn=conn, assert_width=1)))
     if cke is not None:
         io.append(Subsignal("clk_en", Pins(cke, dir="o", conn=conn, assert_width=1)))
-    if cs is not None:
-        io.append(Subsignal("cs",  PinsN(cs,  dir="o", conn=conn, assert_width=1)))
-    io.append(Subsignal("we",  PinsN(we,  dir="o", conn=conn, assert_width=1)))
-    io.append(Subsignal("ras", PinsN(ras, dir="o", conn=conn, assert_width=1)))
-    io.append(Subsignal("cas", PinsN(cas, dir="o", conn=conn, assert_width=1)))
+    if cs_n is not None:
+        io.append(Subsignal("cs_n",  PinsN(cs_n,  dir="o", conn=conn, assert_width=1)))
+    io.append(Subsignal("we_n",  PinsN(we_n,  dir="o", conn=conn, assert_width=1)))
+    io.append(Subsignal("ras_n", PinsN(ras_n, dir="o", conn=conn, assert_width=1)))
+    io.append(Subsignal("cas_n", PinsN(cas_n, dir="o", conn=conn, assert_width=1)))
     io.append(Subsignal("ba", Pins(ba, dir="o", conn=conn)))
     io.append(Subsignal("a",  Pins(a,  dir="o", conn=conn)))
     io.append(Subsignal("dq", Pins(dq, dir="io", conn=conn)))
@@ -124,20 +124,20 @@ def SDRAMResource(*args, clk, cke=None, cs=None, we, ras, cas, ba, a, dq, dqm=No
     return Resource.family(*args, default_name="sdram", ios=io)
 
 
-def NORFlashResources(*args, rst=None, byte=None, cs, oe, we, wp, by, a, dq,
+def NORFlashResources(*args, rst=None, byte_n=None, cs_n, oe_n, we_n, wp_n, by, a, dq,
                       conn=None, attrs=None):
     resources = []
 
     io_common = []
     if rst is not None:
         io_common.append(Subsignal("rst", Pins(rst, dir="o", conn=conn, assert_width=1)))
-    io_common.append(Subsignal("cs", PinsN(cs, dir="o", conn=conn, assert_width=1)))
-    io_common.append(Subsignal("oe", PinsN(oe, dir="o", conn=conn, assert_width=1)))
-    io_common.append(Subsignal("we", PinsN(we, dir="o", conn=conn, assert_width=1)))
-    io_common.append(Subsignal("wp", PinsN(wp, dir="o", conn=conn, assert_width=1)))
+    io_common.append(Subsignal("cs", PinsN(cs_n, dir="o", conn=conn, assert_width=1)))
+    io_common.append(Subsignal("oe", PinsN(oe_n, dir="o", conn=conn, assert_width=1)))
+    io_common.append(Subsignal("we", PinsN(we_n, dir="o", conn=conn, assert_width=1)))
+    io_common.append(Subsignal("wp", PinsN(wp_n, dir="o", conn=conn, assert_width=1)))
     io_common.append(Subsignal("rdy", Pins(by, dir="i", conn=conn, assert_width=1)))
 
-    if byte is None:
+    if byte_n is None:
         io_8bit = list(io_common)
         io_8bit.append(Subsignal("a", Pins(a, dir="o", conn=conn)))
         io_8bit.append(Subsignal("dq", Pins(dq, dir="io", conn=conn, assert_width=8)))
@@ -147,7 +147,7 @@ def NORFlashResources(*args, rst=None, byte=None, cs, oe, we, wp, by, a, dq,
         *dq_0_14, dq15_am1 = dq.split()
 
         # If present in a requested resource, this pin needs to be strapped correctly.
-        io_common.append(Subsignal("byte", PinsN(byte, dir="o", conn=conn, assert_width=1)))
+        io_common.append(Subsignal("byte_n", PinsN(byte_n, dir="o", conn=conn, assert_width=1)))
 
         io_8bit = list(io_common)
         io_8bit.append(Subsignal("a", Pins(" ".join((dq15_am1, a)), dir="o", conn=conn)))

--- a/nmigen_boards/rz_easyfpga_a2_2.py
+++ b/nmigen_boards/rz_easyfpga_a2_2.py
@@ -14,14 +14,14 @@ class RZEasyFPGAA2_2Platform(IntelPlatform):
     package     = "E22"    # EQFP 144 pins
     speed       = "C8"
     default_clk = "clk50"  # 50MHz builtin clock
-    default_rst = "rst"
+    default_rst = "rst_n"
     resources   = [
         # Clock
         Resource("clk50", 0, Pins("23", dir="i"),
                  Clock(50e6), Attrs(io_standard="3.3-V LVTTL")),
 
         # Reset switch, located on the lower left of the board.
-        Resource("rst", 0, PinsN("25", dir="i"), Attrs(io_standard="3.3-V LVTTL")),
+        Resource("rst_n", 0, PinsN("25", dir="i"), Attrs(io_standard="3.3-V LVTTL")),
 
         # LEDs, located on the bottom of the board.
         *LEDResources(
@@ -70,7 +70,7 @@ class RZEasyFPGAA2_2Platform(IntelPlatform):
         I2CResource(1, scl="99" , sda="98" ),
 
         # Buzzer
-        Resource("buzzer", 0, PinsN("110", dir="o")),
+        Resource("buzzer_n", 0, PinsN("110", dir="o")),
 
         # Serial port, located above the VGA port.
         UARTResource(0, tx="114", rx="115"),

--- a/nmigen_boards/supercon19badge.py
+++ b/nmigen_boards/supercon19badge.py
@@ -44,7 +44,7 @@ class Supercon19BadgePlatform(LatticeECP5Platform):
         Resource("clk8", 0, Pins("U18"), Clock(8e6), Attrs(IO_TYPE="LVCMOS33")),
 
         # Used to trigger FPGA reconfiguration.
-        Resource("program", 0, PinsN("R1"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("program_n", 0, PinsN("R1"), Attrs(IO_TYPE="LVCMOS33")),
 
         # See note above for LED anode/cathode information.
         # Short version is: these work as normal LEDs until you touch their cathodes.
@@ -77,8 +77,8 @@ class Supercon19BadgePlatform(LatticeECP5Platform):
         Resource("hdmi", 0,
             Subsignal("clk", DiffPairsN("P20", "R20"), Attrs(IO_TYPE="TMDS_33")),
             Subsignal("d", DiffPairs("N19 L20 L16", "N20 M20 L17"), Attrs(IO_TYPE="TMDS_33")),
-            Subsignal("hpd", PinsN("R18"), Attrs(IO_TYPE="LVCMOS33")),# Also called HDMI_HEAC_n
-            Subsignal("hdmi_heac_p", PinsN("T19"), Attrs(IO_TYPE="LVCMOS33")),
+            Subsignal("hpd_n", PinsN("R18"), Attrs(IO_TYPE="LVCMOS33")),# Also called HDMI_HEAC_n
+            Subsignal("hdmi_heac_p_n", PinsN("T19"), Attrs(IO_TYPE="LVCMOS33")),
             Attrs(DRIVE="4"),
         ),
 
@@ -98,7 +98,7 @@ class Supercon19BadgePlatform(LatticeECP5Platform):
         ),
 
         Resource("spi_flash", 0, # clock needs to be accessed through USRMCLK
-            Subsignal("cs",   PinsN("R2")),
+            Subsignal("cs_n", PinsN("R2")),
             Subsignal("copi", Pins("W2")),
             Subsignal("cipo", Pins("V2")),
             Subsignal("wp",   Pins("Y2")),
@@ -106,20 +106,20 @@ class Supercon19BadgePlatform(LatticeECP5Platform):
             Attrs(IO_TYPE="LVCMOS33")
         ),
         Resource("spi_flash_4x", 0, # clock needs to be accessed through USRMCLK
-            Subsignal("cs",   PinsN("R2")),
+            Subsignal("cs_n", PinsN("R2")),
             Subsignal("dq",   Pins("W2 V2 Y2 W1")),
             Attrs(IO_TYPE="LVCMOS33")
         ),
 
         # SPI-connected PSRAM.
         Resource("spi_psram_4x", 0,
-            Subsignal("cs",  PinsN("D20")),
-            Subsignal("clk", Pins("E20")),
-            Subsignal("dq",  Pins("E19 D19 C20 F19"), Attrs(PULLMODE="UP")),
+            Subsignal("cs_n", PinsN("D20")),
+            Subsignal("clk",  Pins("E20")),
+            Subsignal("dq",   Pins("E19 D19 C20 F19"), Attrs(PULLMODE="UP")),
             Attrs(IO_TYPE="LVCMOS33", SLEWRATE="SLOW")
         ),
         Resource("spi_psram_4x", 1,
-            Subsignal("cs",   PinsN("F20")),
+            Subsignal("cs_n", PinsN("F20")),
             Subsignal("clk",  Pins("J19")),
             Subsignal("dq",   Pins("J20 G19 G20 H20"), Attrs(PULLMODE="UP")),
             Attrs(IO_TYPE="LVCMOS33", SLEWRATE="SLOW")

--- a/nmigen_boards/ulx3s.py
+++ b/nmigen_boards/ulx3s.py
@@ -26,12 +26,12 @@ class _ULX3SPlatform(LatticeECP5Platform):
         Resource("program", 0, PinsN("M4", dir="o"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")),
 
         *LEDResources(pins="B2 C2 C1 D2 D1 E2 E1 H3",
-            attrs=Attrs(IO_STANDARD="LVCMOS33", DRIVE="4")),
+            attrs=Attrs(IO_TYPE="LVCMOS33", DRIVE="4")),
         *ButtonResources(pins="R1 T1 R18 V1 U1 H16",
-            attrs=Attrs(IO_STANDARD="LVCMOS33", PULLMODE="DOWN")
+            attrs=Attrs(IO_TYPE="LVCMOS33", PULLMODE="DOWN")
         ),
         *ButtonResources("switch", pins="E8 D8 D7 E7",
-            attrs=Attrs(IO_STANDARD="LVCMOS33", PULLMODE="DOWN")
+            attrs=Attrs(IO_TYPE="LVCMOS33", PULLMODE="DOWN")
         ),
 
         # Semantic aliases by button label.

--- a/nmigen_boards/ulx3s.py
+++ b/nmigen_boards/ulx3s.py
@@ -23,7 +23,7 @@ class _ULX3SPlatform(LatticeECP5Platform):
         Resource("clk25", 0, Pins("G2", dir="i"), Clock(25e6), Attrs(IO_TYPE="LVCMOS33")),
 
         # Used to reload FPGA configuration.
-        Resource("program", 0, PinsN("M4", dir="o"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")),
+        Resource("program_n", 0, PinsN("M4", dir="o"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")),
 
         *LEDResources(pins="B2 C2 C1 D2 D1 E2 E1 H3",
             attrs=Attrs(IO_TYPE="LVCMOS33", DRIVE="4")),
@@ -35,7 +35,7 @@ class _ULX3SPlatform(LatticeECP5Platform):
         ),
 
         # Semantic aliases by button label.
-        Resource("button_pwr",   0, PinsN("D6", dir="i"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")),
+        Resource("button_pwr_n", 0, PinsN("D6", dir="i"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")),
         Resource("button_fire",  0, Pins("R1",  dir="i"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="DOWN")),
         Resource("button_fire",  1, Pins("T1",  dir="i"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="DOWN")),
         Resource("button_up",    0, Pins("R18", dir="i"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="DOWN")),
@@ -57,11 +57,11 @@ class _ULX3SPlatform(LatticeECP5Platform):
 
         # SPI Flash clock is accessed via USR_MCLK instance.
         Resource("spi_flash", 0,
-            Subsignal("cs",   PinsN("R2", dir="o")),
-            Subsignal("copi", Pins("W2", dir="o")),
-            Subsignal("cipo", Pins("V2", dir="i")),
-            Subsignal("hold", PinsN("W1", dir="o")),
-            Subsignal("wp",   PinsN("Y2", dir="o")),
+            Subsignal("cs_n",   PinsN("R2", dir="o")),
+            Subsignal("copi",   Pins("W2", dir="o")),
+            Subsignal("cipo",   Pins("V2", dir="i")),
+            Subsignal("hold_n", PinsN("W1", dir="o")),
+            Subsignal("wp_n",   PinsN("Y2", dir="o")),
             Attrs(PULLMODE="NONE", DRIVE="4", IO_TYPE="LVCMOS33")
         ),
 

--- a/nmigen_boards/upduino_v1.py
+++ b/nmigen_boards/upduino_v1.py
@@ -14,11 +14,11 @@ class UpduinoV1Platform(LatticeICE40Platform):
     resources   = [
         *LEDResources(pins="39 40 41", invert=True,
                       attrs=Attrs(IO_STANDARD="SB_LVCMOS")),
-        Resource("led_g", 0, PinsN("39", dir="o"),
+        Resource("led_g_n", 0, PinsN("39", dir="o"),
                  Attrs(IO_STANDARD="SB_LVCMOS")),
-        Resource("led_b", 0, PinsN("40", dir="o"),
+        Resource("led_b_n", 0, PinsN("40", dir="o"),
                  Attrs(IO_STANDARD="SB_LVCMOS")),
-        Resource("led_r", 0, PinsN("41", dir="o"),
+        Resource("led_r_n", 0, PinsN("41", dir="o"),
                  Attrs(IO_STANDARD="SB_LVCMOS")),
 
         *SPIFlashResources(0,

--- a/nmigen_boards/versa_ecp5.py
+++ b/nmigen_boards/versa_ecp5.py
@@ -56,7 +56,7 @@ class VersaECP5Platform(LatticeECP5Platform):
 
         *SPIFlashResources(0,
             cs="R2", clk="U3", cipo="W2", copi="V2", wp="Y2", hold="W1",
-            attrs=Attrs(IO_STANDARD="LVCMOS33")
+            attrs=Attrs(IO_TYPE="LVCMOS33")
         ),
 
         Resource("eth_clk125",     0, Pins("L19", dir="i"),

--- a/nmigen_boards/versa_ecp5.py
+++ b/nmigen_boards/versa_ecp5.py
@@ -14,9 +14,9 @@ class VersaECP5Platform(LatticeECP5Platform):
     package     = "BG381"
     speed       = "8"
     default_clk = "clk100"
-    default_rst = "rst"
+    default_rst = "rst_n"
     resources   = [
-        Resource("rst", 0, PinsN("T1", dir="i"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("rst_n", 0, PinsN("T1", dir="i"), Attrs(IO_TYPE="LVCMOS33")),
         Resource("clk100", 0, DiffPairs("P3", "P4", dir="i"),
                  Clock(100e6), Attrs(IO_TYPE="LVDS")),
         Resource("pclk", 0, DiffPairs("A4", "A5", dir="i"),
@@ -26,21 +26,21 @@ class VersaECP5Platform(LatticeECP5Platform):
                       attrs=Attrs(IO_TYPE="LVCMOS25")),
 
         Resource("alnum_led", 0,
-            Subsignal("a", PinsN("M20", dir="o")),
-            Subsignal("b", PinsN("L18", dir="o")),
-            Subsignal("c", PinsN("M19", dir="o")),
-            Subsignal("d", PinsN("L16", dir="o")),
-            Subsignal("e", PinsN("L17", dir="o")),
-            Subsignal("f", PinsN("M18", dir="o")),
-            Subsignal("g", PinsN("N16", dir="o")),
-            Subsignal("h", PinsN("M17", dir="o")),
-            Subsignal("j", PinsN("N18", dir="o")),
-            Subsignal("k", PinsN("P17", dir="o")),
-            Subsignal("l", PinsN("N17", dir="o")),
-            Subsignal("m", PinsN("P16", dir="o")),
-            Subsignal("n", PinsN("R16", dir="o")),
-            Subsignal("p", PinsN("R17", dir="o")),
-            Subsignal("dp", PinsN("U1", dir="o")),
+            Subsignal("a_n",  PinsN("M20", dir="o")),
+            Subsignal("b_n",  PinsN("L18", dir="o")),
+            Subsignal("c_n",  PinsN("M19", dir="o")),
+            Subsignal("d_n",  PinsN("L16", dir="o")),
+            Subsignal("e_n",  PinsN("L17", dir="o")),
+            Subsignal("f_n",  PinsN("M18", dir="o")),
+            Subsignal("g_n",  PinsN("N16", dir="o")),
+            Subsignal("h_n",  PinsN("M17", dir="o")),
+            Subsignal("j_n",  PinsN("N18", dir="o")),
+            Subsignal("k_n",  PinsN("P17", dir="o")),
+            Subsignal("l_n",  PinsN("N17", dir="o")),
+            Subsignal("m_n",  PinsN("P16", dir="o")),
+            Subsignal("n_n",  PinsN("R16", dir="o")),
+            Subsignal("p_n",  PinsN("R17", dir="o")),
+            Subsignal("dp_n", PinsN("U1",  dir="o")),
             Attrs(IO_TYPE="LVCMOS25")
         ),
 
@@ -64,7 +64,7 @@ class VersaECP5Platform(LatticeECP5Platform):
         Resource("eth_clk125_pll", 0, Pins("U16", dir="i"),
                  Clock(125e6), Attrs(IO_TYPE="LVCMOS25")), # NC by default
         Resource("eth_rgmii", 0,
-            Subsignal("rst",     PinsN("U17", dir="o")),
+            Subsignal("rst_n",   PinsN("U17", dir="o")),
             Subsignal("mdc",     Pins("T18", dir="o")),
             Subsignal("mdio",    Pins("U18", dir="io")),
             Subsignal("tx_clk",  Pins("P19", dir="o")),
@@ -76,7 +76,7 @@ class VersaECP5Platform(LatticeECP5Platform):
             Attrs(IO_TYPE="LVCMOS25")
         ),
         Resource("eth_sgmii", 0,
-            Subsignal("rst",     PinsN("U17", dir="o"), Attrs(IO_TYPE="LVCMOS25")),
+            Subsignal("rst_n",   PinsN("U17", dir="o"), Attrs(IO_TYPE="LVCMOS25")),
             Subsignal("mdc",     Pins("T18", dir="o"), Attrs(IO_TYPE="LVCMOS25")),
             Subsignal("mdio",    Pins("U18", dir="io"), Attrs(IO_TYPE="LVCMOS25")),
             Subsignal("tx",      DiffPairs("W13", "W14", dir="o")),
@@ -88,7 +88,7 @@ class VersaECP5Platform(LatticeECP5Platform):
         Resource("eth_clk125_pll", 1, Pins("C18", dir="i"),
                  Clock(125e6), Attrs(IO_TYPE="LVCMOS25")), # NC by default
         Resource("eth_rgmii", 1,
-            Subsignal("rst",     PinsN("F20", dir="o")),
+            Subsignal("rst_n",   PinsN("F20", dir="o")),
             Subsignal("mdc",     Pins("G19", dir="o")),
             Subsignal("mdio",    Pins("H20", dir="io")),
             Subsignal("tx_clk",  Pins("C20", dir="o")),
@@ -100,7 +100,7 @@ class VersaECP5Platform(LatticeECP5Platform):
             Attrs(IO_TYPE="LVCMOS25")
         ),
         Resource("eth_sgmii", 1,
-            Subsignal("rst",     PinsN("F20", dir="o"), Attrs(IO_TYPE="LVCMOS25")),
+            Subsignal("rst_n",   PinsN("F20", dir="o"), Attrs(IO_TYPE="LVCMOS25")),
             Subsignal("mdc",     Pins("G19", dir="o"), Attrs(IO_TYPE="LVCMOS25")),
             Subsignal("mdio",    Pins("H20", dir="io"), Attrs(IO_TYPE="LVCMOS25")),
             Subsignal("tx",      DiffPairs("W17", "W18", dir="o")),
@@ -108,13 +108,13 @@ class VersaECP5Platform(LatticeECP5Platform):
         ),
 
         Resource("ddr3", 0,
-            Subsignal("rst",     PinsN("N4", dir="o")),
+            Subsignal("rst_n",   PinsN("N4", dir="o")),
             Subsignal("clk",     DiffPairs("M4", "N5", dir="o"), Attrs(IO_TYPE="SSTL135D_I")),
             Subsignal("clk_en",  Pins("N2", dir="o")),
-            Subsignal("cs",      PinsN("K1", dir="o")),
-            Subsignal("we",      PinsN("M1", dir="o")),
-            Subsignal("ras",     PinsN("P1", dir="o")),
-            Subsignal("cas",     PinsN("L1", dir="o")),
+            Subsignal("cs_n",    PinsN("K1", dir="o")),
+            Subsignal("we_n",    PinsN("M1", dir="o")),
+            Subsignal("ras_n",   PinsN("P1", dir="o")),
+            Subsignal("cas_n",   PinsN("L1", dir="o")),
             Subsignal("a",       Pins("P2 C4 E5 F5 B3 F4 B5 E4 C5 E3 D5 B4 C3", dir="o")),
             Subsignal("ba",      Pins("P5 N3 M3", dir="o")),
             Subsignal("dqs",     DiffPairs("K2 H4", "J1 G5", dir="io"), Attrs(IO_TYPE="SSTL135D_I", DIFFRESISTOR="100", TERMINATION="OFF")),


### PR DESCRIPTION
This commit adds the `_n` suffix to signal names that use `PinsN` and adds it to function parameter names. It also changes the default reset signal name in cases where it would change to `rst_n`.