### PR TITLE
TinyFPGA AX2: Set internal oscillator as default

### DIFF
--- a/nmigen_boards/tinyfpga_ax2.py
+++ b/nmigen_boards/tinyfpga_ax2.py
@@ -9,6 +9,7 @@ __all__ = ["TinyFPGAAX2Platform"]
 class TinyFPGAAX2Platform(LatticeMachXO2Platform):
     device      = "LCMXO2-1200HC"
     package     = "SG32"
+    default_clk = "OSCH"
     speed       = "4"
     connectors  = [
         Connector("gpio", 0,

--- a/nmigen_boards/tinyfpga_ax2.py
+++ b/nmigen_boards/tinyfpga_ax2.py
@@ -9,7 +9,7 @@ __all__ = ["TinyFPGAAX2Platform"]
 class TinyFPGAAX2Platform(LatticeMachXO2Platform):
     device      = "LCMXO2-1200HC"
     package     = "SG32"
-    default_clk = "OSCH"
+    default_clk = "OSCH" # Leave as OSCH to use the internal clock
     speed       = "4"
     connectors  = [
         Connector("gpio", 0,
@@ -22,4 +22,5 @@ class TinyFPGAAX2Platform(LatticeMachXO2Platform):
         ),
     ]
     resources = []
+    osch_frequency = 2.08 # Only required if using OSCH. Use one of the allowed clock frequencies!
     # This board doesn't have an integrated programmer.


### PR DESCRIPTION
This PR changes the TinyFPGA AX2 board to use the internal high-speed oscillator by default, since the board has no external clock and thus no default `sync` domain.

Notice: This PR is dependent on https://github.com/nmigen/nmigen/pull/575 being merged. Until then, it would cause an error since OSCH is not a valid resource on the TinyFPGA AX2 board.