### PR TITLE
ecpix-5: ddr3: Add missing address pin.

### DIFF
--- a/nmigen_boards/ecpix5.py
+++ b/nmigen_boards/ecpix5.py
@@ -66,7 +66,7 @@ class _ECPIX5Platform(LatticeECP5Platform):
             Subsignal("we",     PinsN("R3", dir="o")),
             Subsignal("ras",    PinsN("T3", dir="o")),
             Subsignal("cas",    PinsN("P2", dir="o")),
-            Subsignal("a",      Pins("T5 M3 L3 V6 K2 W6 K3 L1 H2 L2 N1 J1 M1 K1", dir="o")),
+            Subsignal("a",      Pins("T5 M3 L3 V6 K2 W6 K3 L1 H2 L2 N1 J1 M1 K1 H1", dir="o")),
             Subsignal("ba",     Pins("U6 N3 N4", dir="o")),
             Subsignal("dqs",    DiffPairs("V4 V1", "U5 U2", dir="io"),
                                 Attrs(IO_TYPE="SSTL135D_I", TERMINATION="OFF", DIFFRESISTOR="100")),


### PR DESCRIPTION
Also adjust IO_TYPE attribute to match VCCIO which is 1.5v for this board.
This is not a functional change because both SSTL135 and SSTL15 generate identical bitcode.
But it will hopefully prevent some confusion and will match the litex_boards config.