### PR TITLE
ecpix-5: ddr3: Adjust IO_TYPE attribute to match VCCIO which is 1.5v …

### DIFF
--- a/nmigen_boards/ecpix5.py
+++ b/nmigen_boards/ecpix5.py
@@ -61,7 +61,7 @@ class _ECPIX5Platform(LatticeECP5Platform):
         Resource("eth_int", 0, PinsN("B13", dir="i"), Attrs(IO_TYPE="LVCMOS33")),
 
         Resource("ddr3", 0,
-            Subsignal("clk",    DiffPairs("H3", "J3", dir="o"), Attrs(IO_TYPE="SSTL135D_I")),
+            Subsignal("clk",    DiffPairs("H3", "J3", dir="o"), Attrs(IO_TYPE="SSTL15D_I")),
             Subsignal("clk_en", Pins("P1", dir="o")),
             Subsignal("we",     PinsN("R3", dir="o")),
             Subsignal("ras",    PinsN("T3", dir="o")),
@@ -69,12 +69,12 @@ class _ECPIX5Platform(LatticeECP5Platform):
             Subsignal("a",      Pins("T5 M3 L3 V6 K2 W6 K3 L1 H2 L2 N1 J1 M1 K1 H1", dir="o")),
             Subsignal("ba",     Pins("U6 N3 N4", dir="o")),
             Subsignal("dqs",    DiffPairs("V4 V1", "U5 U2", dir="io"),
-                                Attrs(IO_TYPE="SSTL135D_I", TERMINATION="OFF", DIFFRESISTOR="100")),
+                                Attrs(IO_TYPE="SSTL15D_I", TERMINATION="OFF", DIFFRESISTOR="100")),
             Subsignal("dq",     Pins("T4 W4 R4 W5 R6 P6 P5 P4 R1 W3 T2 V3 U3 W1 T1 W2", dir="io"),
                                 Attrs(TERMINATION="75")),
             Subsignal("dm",     Pins("U4 U1", dir="o")),
             Subsignal("odt",    Pins("P3", dir="o")),
-            Attrs(IO_TYPE="SSTL135_I", SLEWRATE="FAST")
+            Attrs(IO_TYPE="SSTL15_I", SLEWRATE="FAST")
         ),
 
         Resource("sata", 0,


### PR DESCRIPTION
…for this board.

This is not a functional change because both SSTL135 and SSTL15 generate identical bitcode.
But it will hopefully prevent some confusion and will match the litex_boards config.