### PR TITLE
ulx3s: fix pin mapping for audio at ring 2

### DIFF
--- a/nmigen_boards/ulx3s.py
+++ b/nmigen_boards/ulx3s.py
@@ -80,7 +80,7 @@ class _ULX3SPlatform(LatticeECP5Platform):
         Resource("audio", 0,
             Subsignal("l", Pins("E4 D3 C3 B3", dir="o")),
             Subsignal("r", Pins("A3 B5 D5 C5", dir="o")),
-            Subsignal("ring2", Pins("A3 B5 D5 C5", dir="o")), # extra ring out for video adapters
+            Subsignal("ring2", Pins("H5 F2 F5 E5", dir="o")), # extra ring out for video adapters
         ),
 
         # ESP-32 connections


### PR DESCRIPTION
The pin mappings for ring 1 and 2 of the trrs jack were the same.
Fixed with the pinout from [the ulx3s manual](https://github.com/emard/ulx3s/blob/master/doc/constraints/ulx3s_v20.lpf).