### PR TITLE
arty_a7: add missing constraints

### DIFF
--- a/nmigen_boards/arty_a7.py
+++ b/nmigen_boards/arty_a7.py
@@ -204,7 +204,11 @@ class ArtyA7Platform(Xilinx7SeriesPlatform):
                 "write_cfgmem -force -format bin -interface spix4 -size 16 "
                 "-loadbit \"up 0x0 {name}.bit\" -file {name}.bin".format(name=name),
             "add_constraints":
-                "set_property INTERNAL_VREF 0.675 [get_iobanks 34]"
+                """
+                set_property INTERNAL_VREF 0.675 [get_iobanks 34]
+                set_property CFGBVS VCCO [current_design]
+                set_property CONFIG_VOLTAGE 3.3 [current_design]
+                """
         }
         return super().toolchain_prepare(fragment, name, **overrides, **kwargs)
 


### PR DESCRIPTION
This fixes the following warning:
```
WARNING: [DRC CFGBVS-1] Missing CFGBVS and CONFIG_VOLTAGE Design Properties: Neither the CFGBVS nor CONFIG_VOLTAGE voltage property is set in the current_design.  Configuration bank voltage select (CFGBVS) must be set to VCCO or GND, and CONFIG_VOLTAGE must be set to the correct configuration voltage, in order to determine the I/O voltage support for the pins in bank 0.  It is suggested to specify these either using the 'Edit Device Properties' function in the GUI or directly in the XDC file using the following syntax:

 set_property CFGBVS value1 [current_design]
 #where value1 is either VCCO or GND

 set_property CONFIG_VOLTAGE value2 [current_design]
 #where value2 is the voltage provided to configuration bank 0
```

ref: https://github.com/Digilent/Arty/issues/5