### PR TITLE
arty_a7: support both the 35T and 100T SKUs

### DIFF
--- a/nmigen_boards/arty_a7.py
+++ b/nmigen_boards/arty_a7.py
@@ -6,11 +6,10 @@ from nmigen.vendor.xilinx_7series import *
 from .resources import *
 
 
-__all__ = ["ArtyA7Platform"]
+__all__ = ["ArtyA7_35Platform", "ArtyA7_100Platform"]
 
 
-class ArtyA7Platform(Xilinx7SeriesPlatform):
-    device      = "xc7a35ti"
+class _ArtyA7Platform(Xilinx7SeriesPlatform):
     package     = "csg324"
     speed       = "1L"
     default_clk = "clk100"
@@ -218,6 +217,14 @@ class ArtyA7Platform(Xilinx7SeriesPlatform):
             subprocess.run([xc3sprog, "-c", "nexys4", bitstream_filename], check=True)
 
 
+class ArtyA7_35Platform(_ArtyA7Platform):
+    device      = "xc7a35ti"
+
+
+class ArtyA7_100Platform(_ArtyA7Platform):
+    device      = "xc7a100ti"
+
+
 if __name__ == "__main__":
     from .test.blinky import *
-    ArtyA7Platform().build(Blinky(), do_program=True)
+    ArtyA7_35Platform().build(Blinky(), do_program=True)


### PR DESCRIPTION
Similar to the Arty S7, the Arty A7 comes in two variants: one with the Xilinx Artix A7 XC7A35TI SKU and the other with the Xilinx Artix A7 XC7A100TI SKU. I have a board with the latter, and ran the Blinky test to be sure that the following commit does not contain any regressions.

Basically the commit follows the same structure as the arty_s7 board by changing `ArtyA7Platform` to `_ArtyA7Platform` and not setting the device constant. Then it introduces `ArtyA7_35Platform` and `ArtyA7_100Platform` for the two different variants, inheriting `_ArtyA7Platform` and setting the device constant to the appropriate SKU for that platform. Finally, the test has been changed to default to running Blinky on the `ArtyA7_35Platform`.