### PR TITLE
Factor out PS2

### DIFF
--- a/nmigen_boards/atlys.py
+++ b/nmigen_boards/atlys.py
@@ -59,16 +59,10 @@ class AtlysPlatform(XilinxSpartan6Platform):
 
         UARTResource(0, rx="A16", tx="B16", attrs=Attrs(IOSTANDARD="LVCMOS33")), # J17/UART
 
-        Resource("ps2", 0, # PS/2 keyboard interface converted from J13 "HOST" USB connector
-            Subsignal("clk",    Pins("P17", dir="i")),
-            Subsignal("dat",    Pins("N15", dir="io")),
-            Attrs(IOSTANDARD="LVCMOS33"),
-        ),
-        Resource("ps2", 1, # PS/2 mouse interface converted from J13 "HOST" USB connector
-            Subsignal("clk",    Pins("N18", dir="i")),
-            Subsignal("dat",    Pins("P18", dir="io")),
-            Attrs(IOSTANDARD="LVCMOS33"),
-        ),
+        PS2Resource(0, # PS/2 keyboard interface converted from J13 "HOST" USB connector
+            clk="P17", dat="N15", attrs=Attrs(IOSTANDARD="LVCMOS33")),
+        PS2Resource(1, # PS/2 mouse interface converted from J13 "HOST" USB connector
+            clk="N18", dat="P18", attrs=Attrs(IOSTANDARD="LVCMOS33")),
 
         *SPIFlashResources(0,
             cs_n="AE14", clk="AH18", copi="AF14", cipo="AF20", wp_n="AG21", hold_n="AG17",

--- a/nmigen_boards/de0.py
+++ b/nmigen_boards/de0.py
@@ -64,16 +64,10 @@ class DE0Platform(IntelPlatform):
             hs="L21", vs="L22",
             attrs=Attrs(io_standard="3.3-V LVTTL")),
 
-        Resource("ps2_host", 0, # Keyboard
-            Subsignal("clk", Pins("P22", dir="i")),
-            Subsignal("dat", Pins("P21", dir="io")),
-            Attrs(io_standard="3.3-V LVTTL")
-        ),
-        Resource("ps2_host", 1, # Mouse
-            Subsignal("clk", Pins("R21", dir="i")),
-            Subsignal("dat", Pins("R22", dir="io")),
-            Attrs(io_standard="3.3-V LVTTL")
-        ),
+        PS2Resource(0, # Keyboard
+            clk="P22", dat="P21", attrs=Attrs(io_standard="3.3-V LVTTL")),
+        PS2Resource(1, # Mouse
+            clk="R21", dat="R22", attrs=Attrs(io_standard="3.3-V LVTTL")),
 
         *SDCardResources(0,
             clk="Y21", cmd="Y22", dat0="AA22", dat3="W21", wp_n="W20",

--- a/nmigen_boards/de0_cv.py
+++ b/nmigen_boards/de0_cv.py
@@ -59,16 +59,10 @@ class DE0CVPlatform(IntelPlatform):
             hs="H8", vs="G8",
             attrs=Attrs(io_standard="3.3-V LVTTL")),
 
-        Resource("ps2_host", 0, # Keyboard
-            Subsignal("clk", Pins("D3", dir="i")),
-            Subsignal("dat", Pins("G2", dir="io")),
-            Attrs(io_standard="3.3-V LVTTL")
-        ),
-        Resource("ps2_host", 1, # Mouse
-            Subsignal("clk", Pins("E2", dir="i")),
-            Subsignal("dat", Pins("G1", dir="io")),
-            Attrs(io_standard="3.3-V LVTTL")
-        ),
+        PS2Resource(0, # Keyboard
+            clk="D3", dat="G2", attrs=Attrs(io_standard="3.3-V LVTTL")),
+        PS2Resource(1, # Mouse
+            clk="E2", dat="G1", attrs=Attrs(io_standard="3.3-V LVTTL")),
 
         *SDCardResources(0,
             clk="H11", cmd="B11", dat0="K9", dat1="D12", dat2="E12", dat3="C11",

--- a/nmigen_boards/mercury.py
+++ b/nmigen_boards/mercury.py
@@ -185,11 +185,8 @@ class MercuryPlatform(XilinxSpartan3APlatform):
     ]
 
     _ps2 = [
-        Resource("ps2", 0,
-             Subsignal("clk", Pins("2", dir="io", conn=("led", 0))),
-             Subsignal("data", Pins("1", dir="io", conn=("led", 0))),
-             Attrs(IOSTANDARD="LVTTL")
-        )
+        PS2Resource(0,
+            clk="2", dat="1", conn=("led", 0), attrs=Attrs(IOSTANDARD="LVTTL")),
     ]
 
     _audio = [

--- a/nmigen_boards/nexys4ddr.py
+++ b/nmigen_boards/nexys4ddr.py
@@ -103,10 +103,9 @@ class Nexys4DDRPlatform(Xilinx7SeriesPlatform):
             attrs=Attrs(IOSTANDARD="LVCMOS33"),
             role="dce"),
 
-        Resource("ps2_host", 0,
-            Subsignal("clk", Pins("F4", dir="i")),
-            Subsignal("dat", Pins("B2", dir="io")),
-            Attrs(IOSTANDARD="LVCMOS33", PULLUP="TRUE")),
+        PS2Resource(0,
+            clk="F4", dat="B2",
+            attrs=Attrs(IOSTANDARD="LVCMOS33", PULLUP="TRUE")),
 
         Resource("eth", 0,                                  # LAN8720A
             Subsignal("mdio",   Pins("A9",      dir="io")),

--- a/nmigen_boards/resources/interface.py
+++ b/nmigen_boards/resources/interface.py
@@ -3,7 +3,7 @@ from nmigen.build import *
 
 __all__ = [
     "UARTResource", "IrDAResource", "SPIResource", "I2CResource",
-    "DirectUSBResource", "ULPIResource"
+    "DirectUSBResource", "ULPIResource", "PS2Resource",
 ]
 
 
@@ -130,3 +130,15 @@ def ULPIResource(*args, data, clk, dir, nxt, stp, rst=None,
     if attrs is not None:
         io.append(attrs)
     return Resource.family(*args, default_name="usb", ios=io)
+
+
+def PS2Resource(*args, clk, dat, conn=None, attrs=None):
+    ios = []
+
+    ios.append(Subsignal("clk", Pins(clk, dir="i", conn=conn, assert_width=1))),
+    ios.append(Subsignal("dat", Pins(dat, dir="io", conn=conn, assert_width=1))),
+
+    if attrs is not None:
+        ios.append(attrs)
+
+    return Resource.family(*args, default_name="ps2", ios=ios)

--- a/nmigen_boards/rz_easyfpga_a2_2.py
+++ b/nmigen_boards/rz_easyfpga_a2_2.py
@@ -54,10 +54,7 @@ class RZEasyFPGAA2_2Platform(IntelPlatform):
         ),
 
         # PS2 port, located on upper right of the board.
-        Resource("ps2_host", 0, 
-            Subsignal("clk", Pins("119", dir="io")),
-            Subsignal("dat", Pins("120", dir="io")),
-        ),
+        PS2Resource(0, clk="119", dat="120"),
 
         # LM75 temperature sensor
         I2CResource(0, scl="112", sda="113"),


### PR DESCRIPTION
The following FPGAs have one or two PS/2 ports to attach a mouse and keyboard with simply a clock and data signal directly connected to the FPGA:

- Atlys
- DE0
- DE0-CV
- Mercury
- Nexys4DDR
- RZEasyFPGAA2.2

This commit factors out the PS2 resource by defining a function `PS2Resource` that takes the clock signal as `clk` and the data signal as `dat`, and replaces any generic resource using `Resource` with `PS2Resource`.

Boards either use "ps2" or "ps2_host" as a name, and I have used the "ps2" name in `PS2Resource`. We can use the "ps2_host" name instead, but I personally much more prefer the controller/peripheral naming if we do that.

This addresses issue #126.