### PR TITLE
Factor out DDR3.

### DIFF
--- a/nmigen_boards/alchitry_au.py
+++ b/nmigen_boards/alchitry_au.py
@@ -41,24 +41,15 @@ class AlchitryAuPlatform(Xilinx7SeriesPlatform):
         ),
 
         # TODO: This is untested
-        Resource("ddr3", 0,
-            Subsignal("rst",     PinsN("D13", dir="o")),
-            Subsignal("clk",     DiffPairs("G14", "F14", dir="o"), Attrs(IOSTANDARD="LVDS")),
-            Subsignal("clk_en",  Pins("D15", dir="o")),
-            Subsignal("cs",      PinsN("D16", dir="o")),
-            Subsignal("we",      PinsN("E11", dir="o")),
-            Subsignal("ras",     PinsN("D11", dir="o")),
-            Subsignal("cas",     PinsN("D14", dir="o")),
-            Subsignal("a",       Pins("F12 G16 G15 E16 H11 G12 H16 H12 H16 H13 E12 H14 F13 J15", dir="o")),
-            Subsignal("ba",      Pins("E13 F15 E15", dir="o")),
-            Subsignal("dqs",     DiffPairs("B15 A15", "B9 A10", dir="io"), Attrs(IOSTANDARD="LVDS")),
-            Subsignal("dq",      Pins("A13 B16 B14 C11 C13 C16 C12 C14 D8 B11 C8 B10 A12 A8 B12 A9",
-                                      dir="io")),
-            Subsignal("dm",      Pins("A14 C9", dir="o")),
-            Subsignal("odt",     Pins("G11", dir="o")),
-            Attrs(IOSTANDARD="LVCMOS15")
-        )
-
+        DDR3Resource(0,
+            rst_n="D13", clk_p="G14", clk_n="F14", clk_en="D15", cs_n="D16", we_n="E11", ras_n="D14", cas_n="D14",
+            a="F12 G16 G15 E16 H11 G12 H16 H12 H16 H13 E12 H14 F13 J15",
+            ba="E13 F15 E15",
+            dqs_p="B15 A15", dqs_n="B9 A10",
+            dq="A13 B16 B14 C11 C13 C16 C12 C14 D8 B11 C8 B10 A12 A8 B12 A9",
+            dm="A14 C9", odt="G11",
+            diff_attrs=Attrs(IOSTANDARD="LVDS"),
+            attrs=Attrs(IOSTANDARD="LVCMOS15")),
     ]
 
     connectors  = [

--- a/nmigen_boards/resources/memory.py
+++ b/nmigen_boards/resources/memory.py
@@ -4,6 +4,7 @@ from nmigen.build import *
 __all__ = [
     "SPIFlashResources", "SDCardResources",
     "SRAMResource", "SDRAMResource", "NORFlashResources",
+    "DDR3Resource",
 ]
 
 
@@ -163,3 +164,27 @@ def NORFlashResources(*args, rst=None, byte_n=None, cs_n, oe_n, we_n, wp_n, by, 
                                          name_suffix="16bit"))
 
     return resources
+
+
+def DDR3Resource(*args, rst_n=None, clk_p, clk_n, clk_en, cs_n, we_n, ras_n, cas_n, a, ba, dqs_p, dqs_n, dq, dm, odt,
+                 conn=None, diff_attrs=None, attrs=None):
+    ios = []
+
+    ios.append(Subsignal("rst", PinsN(rst_n, dir="o", conn=conn, assert_width=1)))
+    ios.append(Subsignal("clk", DiffPairs(clk_p, clk_n, dir="o", conn=conn, assert_width=1), diff_attrs))
+    ios.append(Subsignal("clk_en", Pins(clk_en, dir="o", conn=conn, assert_width=1)))
+    ios.append(Subsignal("cs", PinsN(cs_n, dir="o", conn=conn, assert_width=1)))
+    ios.append(Subsignal("we", PinsN(we_n, dir="o", conn=conn, assert_width=1)))
+    ios.append(Subsignal("ras", PinsN(ras_n, dir="o", conn=conn, assert_width=1)))
+    ios.append(Subsignal("cas", PinsN(cas_n, dir="o", conn=conn, assert_width=1)))
+    ios.append(Subsignal("a", Pins(a, dir="o", conn=conn)))
+    ios.append(Subsignal("ba", Pins(ba, dir="o", conn=conn)))
+    ios.append(Subsignal("dqs", DiffPairs(dqs_p, dqs_n, dir="io", conn=conn), diff_attrs))
+    ios.append(Subsignal("dq", Pins(dq, dir="io", conn=conn)))
+    ios.append(Subsignal("dm", Pins(dm, dir="o", conn=conn)))
+    ios.append(Subsignal("odt", Pins(odt, dir="o", conn=conn, assert_width=1)))
+
+    if attrs is not None:
+        ios.append(attrs)
+
+    return Resource.family(*args, default_name="ddr3", ios=ios)


### PR DESCRIPTION
The following commit factors out any instance of the `Resource` function specifying a 'ddr3' resource with a call to `DDR3Resource`. See also issue #15. The following boards have been updated to use `DDR3Resource`:

- Alchitry Au
- Arty A7
- Arty S7
- ECPIX5
- Genesys2
- OrangeCrab r0.1, r0.2
- versa_ecp5, versa_ecp5_5g

As DDR3 uses differential signalling, `DDR3Resource` accepts `diff_attrs` in addition to `attrs`. Some board also specify different attributes for specific pins like the rst, dq and dqs pins.