### PR TITLE
de10_lite: fix package SKU name

### DIFF
--- a/nmigen_boards/de10_lite.py
+++ b/nmigen_boards/de10_lite.py
@@ -10,9 +10,10 @@ __all__ = ["DE10LitePlatform"]
 
 
 class DE10LitePlatform(IntelPlatform):
-    device      = "10M50DAF484" # MAX10
-    package     = "F23"     # FBGA-484
-    speed       = "I7"
+    device      = "10M50DA" # MAX10
+    package     = "F484"     # FBGA-484
+    speed       = "C7"
+    suffix      = "G"
     default_clk = "clk50"
     resources   = [
         Resource("clk10", 0, Pins("N5", dir="i"),


### PR DESCRIPTION
The DE10 Lite board has the Altera MAX10 (10M50DAF484C7G). This commit fixes the package name, because the current name is invalid according to Quartus 14.1 (introduces the MAX10), 18.1 and 20.1.