### PR TITLE
de10_lite: fix clk50 numbering

### DIFF
--- a/nmigen_boards/de10_lite.py
+++ b/nmigen_boards/de10_lite.py
@@ -17,9 +17,9 @@ class DE10LitePlatform(IntelPlatform):
     resources   = [
         Resource("clk10", 0, Pins("N5", dir="i"),
                  Clock(50e6), Attrs(io_standard="3.3-V LVTTL")),
-        Resource("clk50", 1, Pins("P11", dir="i"),
+        Resource("clk50", 0, Pins("P11", dir="i"),
                  Clock(50e6), Attrs(io_standard="3.3-V LVTTL")),
-        Resource("clk50", 2, Pins("N14", dir="i"),
+        Resource("clk50", 1, Pins("N14", dir="i"),
                  Clock(50e6), Attrs(io_standard="3.3-V LVTTL")),
 
         *LEDResources(


### PR DESCRIPTION
This commit fixes the numbering of the clk50 resources for the DE10 Lite. As the default clock is set to "clk50", it expects "clk50#0" to exist, but the numbering started from 1. In combination with pull request #165, blinky works on the DE10 Lite platform.