### PR TITLE
nandland_go: 7seg displays should be inverted

### DIFF
--- a/nmigen_boards/nandland_go.py
+++ b/nmigen_boards/nandland_go.py
@@ -21,9 +21,9 @@ class NandlandGoPlatform(LatticeICE40Platform):
         *ButtonResources(pins="53 51 54 52"),
 
         Display7SegResource(0,
-            a="3", b="4", c="93", d="91", e="90", f="1", g="2"),
+            a="3", b="4", c="93", d="91", e="90", f="1", g="2", invert=True),
         Display7SegResource(1,
-            a="100", b="99", c="97", d="95", e="94", f="8", g="96"),
+            a="100", b="99", c="97", d="95", e="94", f="8", g="96", invert=True),
 
         UARTResource(0, rx="73", tx="74"),
 


### PR DESCRIPTION
This commit sets `invert=True` for the two 7-segment displays the Nandland Go has, as the signals should be inverted for the 7-segment displays to work properly. I also tested this on the Nandland Go by implementing an 8-bit counter that uses both 7-segment displays to display the current value in hex. I also verified that the DP pin is indeed hardwired to 3V3 instead of being controllable from the FPGA (see [page 2 of the Nandland Go board schematic](https://www.nandland.com/goboard/images/Go_Board_V1.pdf).