### PR TITLE
arrow_deca: the assignments should be appended to what is originally in the QSF

### DIFF
--- a/nmigen_boards/arrow_deca.py
+++ b/nmigen_boards/arrow_deca.py
@@ -62,7 +62,9 @@ class ArrowDECAPlatform(IntelPlatform):
         # file templates before modifying them to avoid modifying the original.
         return {
             **super().file_templates,
-            "{{name}}.qsf": r"""
+            "{{name}}.qsf":
+                super().file_templates.get("{{name}}.qsf") +
+                r"""
                 set_global_assignment -name IOBANK_VCCIO 2.5V -section_id 1A
                 set_global_assignment -name IOBANK_VCCIO 2.5V -section_id 1B
                 set_global_assignment -name IOBANK_VCCIO 2.5V -section_id 2
@@ -77,7 +79,7 @@ class ArrowDECAPlatform(IntelPlatform):
                 set_global_assignment -name AUTO_RESTART_CONFIGURATION OFF
                 set_global_assignment -name ENABLE_CONFIGURATION_PINS OFF
                 set_global_assignment -name ENABLE_BOOT_SEL_PIN OFF
-            """
+                """
         }
 
 


### PR DESCRIPTION
The previous PR #158 currently fails to build because I was too slow in fixing this issue that got introduced last-minute. The assignments should be appended to the template for `{{name}}.qsf` that is already provided by `IntelPlatform`. This commit fixes that and ensures that Blinky works for the Arrow DECA.