### PR TITLE
nandland_go: reorder 7-segment displays

### DIFF
--- a/nmigen_boards/nandland_go.py
+++ b/nmigen_boards/nandland_go.py
@@ -21,9 +21,9 @@ class NandlandGoPlatform(LatticeICE40Platform):
         *ButtonResources(pins="53 51 54 52"),
 
         Display7SegResource(0,
-            a="3", b="4", c="93", d="91", e="90", f="1", g="2", invert=True),
-        Display7SegResource(1,
             a="100", b="99", c="97", d="95", e="94", f="8", g="96", invert=True),
+        Display7SegResource(1,
+            a="3", b="4", c="93", d="91", e="90", f="1", g="2", invert=True),
 
         UARTResource(0, rx="73", tx="74"),
 


### PR DESCRIPTION
The schematics of the Nandland Go number the 7-segment displays from left to right as 1 and 2, and the original commit introducing the Nandland Go numbers the 7-segment displays from left to right. However, the DE10 Lite board numbers the 7-segment displays from right to left. We should probably be sticking to one of the two orders and avoid introducing inconsistencies between boards like this. The right to left ordering probably makes the most sense, as the very first display would be used to display the least-significant nibble. So this pull request changes the order of the 7-segment displays for the Nandland Go to follow the same order as used for the DE10 Lite.

If we instead prefer left to right ordering, then that is fine with me too. I can have a look at the other boards that feature 7-segment displays to ensure the ordering is consistent at least.