### PR TITLE
orangecrab_r0_1: Fix program pin

### DIFF
--- a/nmigen_boards/orangecrab_r0_1.py
+++ b/nmigen_boards/orangecrab_r0_1.py
@@ -21,7 +21,7 @@ class OrangeCrabR0_1Platform(LatticeECP5Platform):
 
         # Used to reload FPGA configuration.
         # Can enter USB bootloader by assigning button 0 to program.
-        Resource("program", 0, PinsN("V17", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
+        Resource("program", 0, PinsN("R16", dir="o"), Attrs(IO_TYPE="LVCMOS33")),
 
         RGBLEDResource(0,
             r="V17", g="T17", b="J3", invert=True,


### PR DESCRIPTION
The program pin is incorrect on the OrangeCrab r0.1.